### PR TITLE
WIP: experimental rpc timer proof of concept

### DIFF
--- a/examples/composition/composed-benchmark.c
+++ b/examples/composition/composed-benchmark.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
 
     /* register core RPC */
     my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc",
-        void, void, NULL);
+        margo_input_null, void, NULL);
     /* register service APIs */
     data_xfer_register_client(mid);
     composed_register_client(mid);
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
     printf("Shutting down delegator server.\n");
     hret = margo_create(mid, delegator_svr_addr, my_rpc_shutdown_id, &handle);
     assert(hret == HG_SUCCESS);
-    hret = margo_forward(handle, NULL);
+    hret = margo_forward(handle, MARGO_INPUT_NULL);
     assert(hret == HG_SUCCESS);
     margo_destroy(handle);
     if(strcmp(argv[1], argv[2]))
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
         printf("Shutting down data_xfer server.\n");
         hret = margo_create(mid, data_xfer_svr_addr, my_rpc_shutdown_id, &handle);
         assert(hret == HG_SUCCESS);
-        hret = margo_forward(handle, NULL);
+        hret = margo_forward(handle, MARGO_INPUT_NULL);
         assert(hret == HG_SUCCESS);
         margo_destroy(handle);
     }

--- a/examples/composition/composed-svc-daemon.c
+++ b/examples/composition/composed-svc-daemon.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
     /* register a shutdown RPC as just a generic handler; not part of a
      * multiplexed service
      */
-    MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, my_rpc_shutdown_ult);
+    MARGO_REGISTER(mid, "my_shutdown_rpc", margo_input_null, void, my_rpc_shutdown_ult);
 
     margo_get_handler_pool(mid, &handler_pool);
     svc = strtok(svc_list, ",");

--- a/examples/composition/data-xfer-proto.h
+++ b/examples/composition/data-xfer-proto.h
@@ -10,8 +10,8 @@
 #include <margo.h>
 #include <mercury_proc_string.h>
 
-MERCURY_GEN_PROC(data_xfer_read_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(data_xfer_read_in_t,
+MARGO_GEN_PROC(data_xfer_read_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(data_xfer_read_in_t,
     ((hg_string_t)(client_addr))\
     ((hg_bulk_t)(bulk_handle)))
 

--- a/examples/composition/delegator-proto.h
+++ b/examples/composition/delegator-proto.h
@@ -10,8 +10,8 @@
 #include <margo.h>
 #include <mercury_proc_string.h>
 
-MERCURY_GEN_PROC(delegator_read_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(delegator_read_in_t,
+MARGO_GEN_PROC(delegator_read_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(delegator_read_in_t,
     ((hg_string_t)(data_xfer_svc_addr))\
     ((hg_bulk_t)(bulk_handle)))
 

--- a/examples/margo-example-client.c
+++ b/examples/margo-example-client.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 
     /* register RPC */
 	my_rpc_id = MARGO_REGISTER(mid, "my_rpc", my_rpc_in_t, my_rpc_out_t, NULL);
-	my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
+	my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc", margo_input_null, void, NULL);
 
     /* find addr for server */
     hret = margo_addr_lookup(mid, argv[1], &svr_addr);
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
     hret = margo_create(mid, svr_addr, my_rpc_shutdown_id, &handle);
     assert(hret == HG_SUCCESS);
 
-    hret = margo_forward(handle, NULL);
+    hret = margo_forward(handle, MARGO_INPUT_NULL);
     assert(hret == HG_SUCCESS);
 
     margo_destroy(handle);

--- a/examples/margo-example-server.c
+++ b/examples/margo-example-server.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 
     /* register RPC */
     MARGO_REGISTER(mid, "my_rpc", my_rpc_in_t, my_rpc_out_t, my_rpc_ult);
-	MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, my_rpc_shutdown_ult);
+    MARGO_REGISTER(mid, "my_shutdown_rpc", margo_input_null, void, my_rpc_shutdown_ult);
 
     /* NOTE: there isn't anything else for the server to do at this point
      * except wait for itself to be shut down.  The

--- a/examples/multiplex/margo-example-mp-client.c
+++ b/examples/multiplex/margo-example-mp-client.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     }
 
     /* register core RPC */
-    my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
+    my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc", margo_input_null, void, NULL);
     /* register service APIs */
     svc1_register_client(mid);
     svc2_register_client(mid);
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
     hret = margo_create(mid, svr_addr, my_rpc_shutdown_id, &handle);
     assert(hret == HG_SUCCESS);
 
-    hret = margo_forward(handle, NULL);
+    hret = margo_forward(handle, MARGO_INPUT_NULL);
     assert(hret == HG_SUCCESS);
 
     margo_destroy(handle);

--- a/examples/multiplex/margo-example-mp-server.c
+++ b/examples/multiplex/margo-example-mp-server.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
     /* register a shutdown RPC as just a generic handler; not part of a
      * multiplexed service
      */
-    MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, my_rpc_shutdown_ult);
+    MARGO_REGISTER(mid, "my_shutdown_rpc", margo_input_null, void, my_rpc_shutdown_ult);
 
     /* register svc1, with provider_id 1, to execute on the default handler pool
      * used by Margo

--- a/examples/multiplex/svc1-proto.h
+++ b/examples/multiplex/svc1-proto.h
@@ -9,13 +9,13 @@
 
 #include <margo.h>
 
-MERCURY_GEN_PROC(svc1_do_thing_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(svc1_do_thing_in_t,
+MARGO_GEN_PROC(svc1_do_thing_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(svc1_do_thing_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 
-MERCURY_GEN_PROC(svc1_do_other_thing_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(svc1_do_other_thing_in_t,
+MARGO_GEN_PROC(svc1_do_other_thing_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(svc1_do_other_thing_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 

--- a/examples/multiplex/svc2-proto.h
+++ b/examples/multiplex/svc2-proto.h
@@ -9,13 +9,13 @@
 
 #include <margo.h>
 
-MERCURY_GEN_PROC(svc2_do_thing_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(svc2_do_thing_in_t,
+MARGO_GEN_PROC(svc2_do_thing_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(svc2_do_thing_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 
-MERCURY_GEN_PROC(svc2_do_other_thing_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(svc2_do_other_thing_in_t,
+MARGO_GEN_PROC(svc2_do_other_thing_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(svc2_do_other_thing_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 

--- a/examples/my-rpc.h
+++ b/examples/my-rpc.h
@@ -11,8 +11,8 @@
 
 /* visible API for example RPC operation */
 
-MERCURY_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(my_rpc_in_t,
+MARGO_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(my_rpc_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 DECLARE_MARGO_RPC_HANDLER(my_rpc_ult)

--- a/tests/my-rpc.h
+++ b/tests/my-rpc.h
@@ -11,14 +11,14 @@
 
 /* visible API for example RPC operation */
 
-MERCURY_GEN_PROC(my_rpc_hang_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(my_rpc_hang_in_t,
+MARGO_GEN_PROC(my_rpc_hang_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(my_rpc_hang_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 DECLARE_MARGO_RPC_HANDLER(my_rpc_hang_ult)
 
-MERCURY_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(my_rpc_in_t,
+MARGO_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
+MARGO_GEN_PROC(my_rpc_in_t,
     ((int32_t)(input_val))\
     ((hg_bulk_t)(bulk_handle)))
 DECLARE_MARGO_RPC_HANDLER(my_rpc_ult)


### PR DESCRIPTION
In GitLab by @carns on May 7, 2019, 09:41

- displays min/avg/max for each type of rpc call issued
- tracks nesting up to 4 deep using 16 bit identifers for each RPC
- uses abt thread local keys to relay through chains of rpcs
- replaces mercury gen proc macros with margo variants that tack on
  additional id for tracing purposes

DO NOT MERGE.  Code is in rough draft form (lacks error handling, uses globals, and prints verbosely to stdout) and modifies margo API.  Just opening WIP PR for tracking purposes.

The method for adding uint64_t rpc_breadcrumb could be better.  The approach used here requires manual intervention for RPCs that don't use GEN_PROC macros, and will duplicate fields when GEN_PROC is nested.