### PR TITLE
WIP: nested rpc statistics collection

### DIFF
--- a/examples/composition/composed-benchmark.c
+++ b/examples/composition/composed-benchmark.c
@@ -60,6 +60,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: margo_init()\n");
         return(-1);
     }
+    margo_diag_start(mid);
 
     /* register core RPC */
     my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc",
@@ -145,6 +146,7 @@ int main(int argc, char **argv)
     margo_addr_free(mid, data_xfer_svr_addr);
 
     /* shut down everything */
+    margo_diag_dump(mid, "-", 0);
     margo_finalize(mid);
     free(buffer);
 

--- a/examples/composition/composed-svc-daemon.c
+++ b/examples/composition/composed-svc-daemon.c
@@ -42,6 +42,7 @@ static void my_rpc_shutdown_ult(hg_handle_t handle)
      * margo_wait_for_finalize() to suspend until this RPC executes, so there
      * is no need to send any extra signal to notify it.
      */
+    margo_diag_dump(mid, "-", 0);
     margo_finalize(mid);
 
     return;
@@ -80,6 +81,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: margo_init()\n");
         return(-1);
     }
+    margo_diag_start(mid);
 
     /* figure out what address this server is listening on */
     hret = margo_addr_self(mid, &addr_self);

--- a/include/margo.h
+++ b/include/margo.h
@@ -31,7 +31,11 @@ extern "C" {
 struct margo_instance;
 typedef struct margo_instance* margo_instance_id;
 typedef struct margo_data* margo_data_ptr;
-typedef ABT_eventual margo_request;
+typedef struct {
+    ABT_eventual eventual;   /* will be set on completion */
+    double start_time;       /* timestamp of when the operation started */
+    uint64_t rpc_breadcrumb; /* statistics tracking identifier, if applicable */ 
+} margo_request;
 
 #define MARGO_INSTANCE_NULL ((margo_instance_id)NULL)
 #define MARGO_REQUEST_NULL ABT_EVENTUAL_NULL
@@ -900,6 +904,15 @@ void __margo_internal_incr_pending(margo_instance_id mid);
 void __margo_internal_decr_pending(margo_instance_id mid);
 
 /**
+ * @private
+ * Internal function used by DEFINE_MARGO_RPC_HANDLER, not supposed to be
+ * called by users!
+ *
+ * @param rpc_breadcrumb RPC tracking breadcrumb
+ */
+void __margo_internal_breadcrumb_handler_set(uint64_t rpc_breadcrumb);
+
+/**
  * macro that registers a function as an RPC.
  */
 #define MARGO_REGISTER(__mid, __func_name, __in_t, __out_t, __handler) \
@@ -921,11 +934,22 @@ void __margo_internal_decr_pending(margo_instance_id mid);
 /**
  * macro that defines a function to glue an RPC handler to a ult handler
  * @param [in] __name name of handler function
+ *
+ * Note: we use this opportunity to set a thread-local argobots key that stores
+ * the "breadcrumb" that was set in the RPC.  It is shifted down 16 bits so that
+ * if this handler in turn issues more RPCs there will be a stack showing their 
+ * ancestry.
  */
 #define DEFINE_MARGO_RPC_HANDLER(__name) \
 void __name##_wrapper(hg_handle_t handle) { \
     margo_instance_id __mid; \
+    hg_return_t __ret; \
+    uint64_t *__rpc_breadcrumb; \
     __mid = margo_hg_handle_get_instance(handle); \
+    __ret = HG_Get_input_buf(handle, (void**)&__rpc_breadcrumb, NULL); \
+    assert(__ret == HG_SUCCESS); \
+    *__rpc_breadcrumb = le64toh(*__rpc_breadcrumb); \
+    __margo_internal_breadcrumb_handler_set((*__rpc_breadcrumb) << 16); \
     __name(handle); \
     __margo_internal_decr_pending(__mid); \
     if(__margo_internal_finalize_requested(__mid)) { \


### PR DESCRIPTION
In GitLab by @carns on May 17, 2019, 13:18

- turn on margo diagnostics to produce output
- min/max/avg for each rpc issued
- identifiers for each rpc include ancestry of rpcs that triggered them
- relies on user-defined Mercury header space and Argobots thread-local
  keys