### PR TITLE
make margo_request type opaque

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -29,12 +29,13 @@ extern "C" {
 #undef MERCURY_REGISTER
 
 struct margo_instance;
+struct margo_request_struct;
 typedef struct margo_instance* margo_instance_id;
 typedef struct margo_data* margo_data_ptr;
-typedef ABT_eventual margo_request;
+typedef struct margo_request_struct* margo_request;
 
 #define MARGO_INSTANCE_NULL ((margo_instance_id)NULL)
-#define MARGO_REQUEST_NULL ABT_EVENTUAL_NULL
+#define MARGO_REQUEST_NULL ((margo_request)NULL)
 #define MARGO_CLIENT_MODE 0
 #define MARGO_SERVER_MODE 1
 #define MARGO_DEFAULT_PROVIDER_ID 0

--- a/src/margo.c
+++ b/src/margo.c
@@ -55,6 +55,17 @@ struct margo_finalize_cb
 
 struct margo_timer_list; /* defined in margo-timer.c */
 
+struct margo_request_struct
+{
+    ABT_eventual eventual;
+    /* NOTE: as long as this struct only has a single ABT_eventual element,
+     * we can safely cast it and use it directly as an ABT_eventual type 
+     * without additional memory allocation.  If we add additional state to
+     * this struct, then the struct type must be allocated to hold the
+     * eventual plus the other fields.
+     */
+};
+
 struct margo_instance
 {
     /* mercury/argobots state */
@@ -880,7 +891,10 @@ hg_return_t margo_wait(margo_request req)
 
     ABT_eventual_wait(req, (void**)&waited_hret);
 	hret = *waited_hret;
-    ABT_eventual_free(&req);
+    /* NOTE: this works when margo_request_struct is just a single field
+     * struct with an ABT_eventual within it
+     */
+    ABT_eventual_free((ABT_eventual*)&req);
 	
     return(hret);
 }


### PR DESCRIPTION
In GitLab by @carns on Jun 19, 2019, 14:01

- should not change behavior right now, but opens up the possibility of
  adding additional (compile-time optional) state to the request later without
  further changes to the public API.