### PR TITLE
add priority pool option

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -143,6 +143,11 @@ struct margo_init_info {
 use_progress_thread: bool (default false)
 rpc_thread_count: integer (default 0)
 
+* Note that supported kinds of pools are fifo_wait (default) fifo (for use
+* with basic scheduler; will busy spin when idle) and prio_wait (custom pool
+* implementation for Margo that favors existing ULTs over newly created ULTs
+* when possible)
+*
  * ------------------------------------------------
  */
 

--- a/src/Makefile.subdir
+++ b/src/Makefile.subdir
@@ -8,4 +8,5 @@ src_libmargo_la_SOURCES += \
  src/margo-logging.c \
  src/margo-timer.h \
  src/margo-timer.c \
- src/margo-util.c
+ src/margo-util.c \
+ src/margo-prio-pool.c

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -214,6 +214,10 @@ static void margo_cleanup(margo_instance_id mid)
     json_object_put(mid->json_cfg);
 
     MARGO_TRACE(mid, "Cleaning up margo instance");
+    for (unsigned i = 0; i < mid->num_abt_pools; i++) {
+        if (mid->abt_pools[i] != ABT_POOL_NULL)
+            ABT_pool_free(&mid->abt_pools[i]);
+    }
     free(mid->abt_pools);
     free(mid->abt_xstreams);
     free(mid->owns_abt_xstream);

--- a/src/margo-prio-pool.c
+++ b/src/margo-prio-pool.c
@@ -1,0 +1,351 @@
+/*
+ * (C) 2021 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <abt.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "margo-prio-pool.h"
+
+/* ABT_POOL_PRIO_WAIT */
+
+/* This is a custom Argobots pool, compatible with ABT_POOL_FIFO_WAIT, that
+ * automatically splits work units into high priority and low priority bins.
+ * Newly created threads (that have never been executed) are assigned a
+ * low priority, while threads that have been executed at least once are
+ * assigned a high priority.  This pool will therefore favor trying to
+ * complete existing ULTs before starting new ones if both are possible.
+ *
+ * The SCHED_COUNTER_PRIORITY_LIMIT is a threshold for the number of times
+ * that an existing ULT may be yielded before it is demoted to the low
+ * priority bin.  This heuristic is mean to ensure that persistent
+ * background threads do not get indefinitely favorable priority.
+ */
+
+/* Once a unit has yielded this many times, it no longer receives a
+ * priority boost, on the assumption that it is a long-running background ULT
+ */
+#define SCHED_COUNTER_PRIORITY_LIMIT 25
+
+typedef struct unit_t {
+    ABT_thread     thread;
+    ABT_task       task;
+    struct unit_t* p_prev;
+    struct unit_t* p_next;
+    int            sched_counter;
+    ABT_bool       is_in_pool;
+} unit_t;
+
+typedef struct queue_t {
+    unit_t* p_tail;
+    unit_t* p_head;
+} queue_t;
+
+static inline void queue_push(queue_t* p_queue, unit_t* p_unit)
+{
+    if (p_queue->p_head == NULL) {
+        p_unit->p_next  = p_unit;
+        p_unit->p_prev  = p_unit;
+        p_queue->p_head = p_unit;
+        p_queue->p_tail = p_unit;
+    } else {
+        unit_t* p_head  = p_queue->p_head;
+        unit_t* p_tail  = p_queue->p_tail;
+        p_tail->p_next  = p_unit;
+        p_head->p_prev  = p_unit;
+        p_unit->p_prev  = p_tail;
+        p_unit->p_next  = p_head;
+        p_queue->p_tail = p_unit;
+    }
+    p_unit->is_in_pool = ABT_TRUE;
+}
+
+static inline unit_t* queue_pop(queue_t* p_queue)
+{
+    if (p_queue->p_head == NULL) {
+        return NULL;
+    } else {
+        unit_t* p_unit = p_queue->p_head;
+        if (p_queue->p_head == p_queue->p_tail) {
+            /* one item */
+            p_queue->p_head = NULL;
+            p_queue->p_tail = NULL;
+        } else {
+            p_unit->p_prev->p_next = p_unit->p_next;
+            p_unit->p_next->p_prev = p_unit->p_prev;
+            p_queue->p_head        = p_unit->p_next;
+        }
+        p_unit->p_next     = NULL;
+        p_unit->p_prev     = NULL;
+        p_unit->is_in_pool = ABT_FALSE;
+        return p_unit;
+    }
+}
+
+typedef struct pool_t {
+    queue_t         high_prio_queue;
+    queue_t         low_prio_queue;
+    int             num;
+    int             cnt;
+    pthread_mutex_t mutex;
+    pthread_cond_t  cond;
+} pool_t;
+
+static ABT_unit_type pool_unit_get_type(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    if (p_unit->thread != ABT_THREAD_NULL) {
+        return ABT_UNIT_TYPE_THREAD;
+    } else {
+        return ABT_UNIT_TYPE_TASK;
+    }
+}
+
+static ABT_thread pool_unit_get_thread(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    return p_unit->thread;
+}
+
+static ABT_task pool_unit_get_task(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    return p_unit->task;
+}
+
+static ABT_bool pool_unit_is_in_pool(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    return p_unit->is_in_pool;
+}
+
+static ABT_unit pool_unit_create_from_thread(ABT_thread thread)
+{
+    unit_t* p_unit        = (unit_t*)malloc(sizeof(unit_t));
+    p_unit->thread        = thread;
+    p_unit->task          = ABT_TASK_NULL;
+    p_unit->p_next        = NULL;
+    p_unit->p_prev        = NULL;
+    p_unit->sched_counter = 0;
+    p_unit->is_in_pool    = ABT_FALSE;
+    return (ABT_unit)p_unit;
+}
+
+static ABT_unit pool_unit_create_from_task(ABT_task task)
+{
+    unit_t* p_unit        = (unit_t*)malloc(sizeof(unit_t));
+    p_unit->thread        = ABT_THREAD_NULL;
+    p_unit->task          = task;
+    p_unit->p_next        = NULL;
+    p_unit->p_prev        = NULL;
+    p_unit->sched_counter = 0;
+    p_unit->is_in_pool    = ABT_FALSE;
+    return (ABT_unit)p_unit;
+}
+
+static void pool_unit_free(ABT_unit* p_unit)
+{
+    free(*p_unit);
+    *p_unit = ABT_UNIT_NULL;
+}
+
+static int pool_init(ABT_pool pool, ABT_pool_config config)
+{
+    pool_t* p_pool                 = (pool_t*)malloc(sizeof(pool_t));
+    p_pool->high_prio_queue.p_tail = NULL;
+    p_pool->high_prio_queue.p_head = NULL;
+    p_pool->low_prio_queue.p_tail  = NULL;
+    p_pool->low_prio_queue.p_head  = NULL;
+    p_pool->num                    = 0;
+    p_pool->cnt                    = 0;
+    pthread_mutex_init(&p_pool->mutex, NULL);
+    pthread_cond_init(&p_pool->cond, NULL);
+    ABT_pool_set_data(pool, (void*)p_pool);
+    return ABT_SUCCESS;
+}
+
+static size_t pool_get_size(ABT_pool pool)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    return p_pool->num;
+}
+
+static void pool_push(ABT_pool pool, ABT_unit unit)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    unit_t* p_unit = (unit_t*)unit;
+    int     sched_counter;
+
+#if 0
+    ABT_thread_state state;
+    /* If it is a thread, look at state */
+    if(p_unit->thread != ABT_THREAD_NULL) {
+        if(ABT_thread_get_state(p_unit->thread, &state) == ABT_SUCCESS) {
+            fprintf(stderr, "DBG: %p state on push: %d\n", p_unit->thread, state);
+        }
+    }
+#endif
+
+    /* save incoming value of push counter, then increment */
+    sched_counter = p_unit->sched_counter;
+    if (p_unit->sched_counter < SCHED_COUNTER_PRIORITY_LIMIT)
+        p_unit->sched_counter++;
+
+    // fprintf(stderr, "DBG: looking at sched_counter %d\n", sched_counter);
+    pthread_mutex_lock(&p_pool->mutex);
+    if (sched_counter == 0 || sched_counter >= SCHED_COUNTER_PRIORITY_LIMIT) {
+        /* The first push or long-running ULT, so put it to the low-priority
+         * pool. */
+        queue_push(&p_pool->low_prio_queue, p_unit);
+    } else {
+        /* high-priority pool, for ULTs that have been suspended more than
+         * once but not excessively
+         */
+        queue_push(&p_pool->high_prio_queue, p_unit);
+    }
+    p_pool->num++;
+    pthread_cond_signal(&p_pool->cond);
+    pthread_mutex_unlock(&p_pool->mutex);
+}
+
+static ABT_unit pool_pop(ABT_pool pool)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+
+    /* Sometimes it should pop from low_prio_queue to avoid a deadlock. */
+    pthread_mutex_lock(&p_pool->mutex);
+    unit_t* p_unit = NULL;
+    do {
+        if ((p_pool->cnt++ & 0xFF) != 0) {
+            p_unit = queue_pop(&p_pool->high_prio_queue);
+            if (p_unit) {
+                // fprintf(stderr, "DBG: found high.\n");
+                break;
+            }
+            p_unit = queue_pop(&p_pool->low_prio_queue);
+            if (p_unit) {
+                // fprintf(stderr, "DBG: found low.\n");
+                break;
+            }
+        } else {
+            p_unit = queue_pop(&p_pool->low_prio_queue);
+            if (p_unit) {
+                // fprintf(stderr, "DBG: found low.\n");
+                break;
+            }
+            p_unit = queue_pop(&p_pool->high_prio_queue);
+            if (p_unit) {
+                // fprintf(stderr, "DBG: found high.\n");
+                break;
+            }
+        }
+    } while (0);
+    if (p_unit) p_pool->num--;
+    pthread_mutex_unlock(&p_pool->mutex);
+    return p_unit ? (ABT_unit)p_unit : ABT_UNIT_NULL;
+}
+
+static inline void convert_double_sec_to_timespec(struct timespec* ts_out,
+                                                  double           seconds)
+{
+    ts_out->tv_sec  = (time_t)seconds;
+    ts_out->tv_nsec = (long)((seconds - ts_out->tv_sec) * 1000000000.0);
+}
+
+static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    /* Sometimes it should pop from low_prio_queue to avoid a deadlock. */
+    pthread_mutex_lock(&p_pool->mutex);
+    unit_t* p_unit = NULL;
+    if (p_pool->num == 0) {
+        struct timespec ts;
+        convert_double_sec_to_timespec(&ts, abstime_secs);
+        pthread_cond_timedwait(&p_pool->cond, &p_pool->mutex, &ts);
+    }
+    do {
+        if ((p_pool->cnt++ & 0xFF) != 0) {
+            p_unit = queue_pop(&p_pool->high_prio_queue);
+            if (p_unit) break;
+            p_unit = queue_pop(&p_pool->low_prio_queue);
+            if (p_unit) break;
+        } else {
+            p_unit = queue_pop(&p_pool->low_prio_queue);
+            if (p_unit) break;
+            p_unit = queue_pop(&p_pool->high_prio_queue);
+            if (p_unit) break;
+        }
+    } while (0);
+    if (p_unit) p_pool->num--;
+    pthread_mutex_unlock(&p_pool->mutex);
+    return p_unit ? (ABT_unit)p_unit : ABT_UNIT_NULL;
+}
+
+static int pool_remove(ABT_pool pool, ABT_unit unit)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    unit_t* p_unit = (unit_t*)unit;
+
+    pthread_mutex_lock(&p_pool->mutex);
+    if (p_unit->p_prev) {
+        p_unit->p_prev->p_next = p_unit->p_next;
+    } else {
+        if (p_pool->high_prio_queue.p_head == p_unit) {
+            p_pool->high_prio_queue.p_head = p_unit->p_next;
+        } else if (p_pool->low_prio_queue.p_head == p_unit) {
+            p_pool->low_prio_queue.p_head = p_unit->p_next;
+        }
+    }
+    if (p_unit->p_next) {
+        p_unit->p_next->p_prev = p_unit->p_prev;
+    } else {
+        if (p_pool->high_prio_queue.p_tail == p_unit) {
+            p_pool->high_prio_queue.p_tail = p_unit->p_prev;
+        } else if (p_pool->low_prio_queue.p_tail == p_unit) {
+            p_pool->low_prio_queue.p_tail = p_unit->p_prev;
+        }
+    }
+    p_pool->num--;
+    pthread_mutex_unlock(&p_pool->mutex);
+
+    return ABT_SUCCESS;
+}
+
+static int pool_free(ABT_pool pool)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    pthread_mutex_destroy(&p_pool->mutex);
+    pthread_cond_destroy(&p_pool->cond);
+    free(p_pool);
+
+    return ABT_SUCCESS;
+}
+
+void margo_create_prio_pool_def(ABT_pool_def* p_def)
+{
+    p_def->access               = ABT_POOL_ACCESS_MPMC;
+    p_def->u_get_type           = pool_unit_get_type;
+    p_def->u_get_thread         = pool_unit_get_thread;
+    p_def->u_get_task           = pool_unit_get_task;
+    p_def->u_is_in_pool         = pool_unit_is_in_pool;
+    p_def->u_create_from_thread = pool_unit_create_from_thread;
+    p_def->u_create_from_task   = pool_unit_create_from_task;
+    p_def->u_free               = pool_unit_free;
+    p_def->p_init               = pool_init;
+    p_def->p_get_size           = pool_get_size;
+    p_def->p_push               = pool_push;
+    p_def->p_pop                = pool_pop;
+    p_def->p_pop_timedwait      = pool_pop_timedwait;
+    p_def->p_remove             = pool_remove;
+    p_def->p_free               = pool_free;
+    p_def->p_print_all          = NULL; /* Optional. */
+}

--- a/src/margo-prio-pool.h
+++ b/src/margo-prio-pool.h
@@ -1,0 +1,22 @@
+/*
+ * (C) 2021 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef __MARGO_PRIO_POOL
+#define __MARGO_PRIO_POOL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <abt.h>
+
+void margo_create_prio_pool_def(ABT_pool_def* p_def);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MARGO_PRIO_POOL */

--- a/tests/Makefile.subdir
+++ b/tests/Makefile.subdir
@@ -15,6 +15,8 @@ TESTS += \
  tests/sleep.sh \
  tests/basic.sh \
  tests/basic-ded-pool.sh \
+ tests/basic-prio.sh \
+ tests/basic-ded-pool-prio.sh \
  tests/timeout.sh
 
 EXTRA_DIST += \
@@ -24,7 +26,7 @@ EXTRA_DIST += \
  tests/timeout.sh \
  tests/test-util.sh \
  tests/test-util-ded-pool.sh
- 
+
 tests_margo_test_server_SOURCES = \
  tests/margo-test-server.c \
  tests/my-rpc.c

--- a/tests/basic-ded-pool-prio.sh
+++ b/tests/basic-ded-pool-prio.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -x
+
+# NOTE: this example uses a dedicated execution stream in Argobots to drive
+# progress on the server
+
+if [ -z $srcdir ]; then
+    echo srcdir variable not set.
+    exit 1
+fi
+source $srcdir/tests/test-util-ded-pool.sh
+
+# start 1 server with 2 second wait, 20s timeout, priority pool
+test_start_servers 1 2 20 prio_wait
+
+sleep 1
+
+#####################
+
+# run client test, which will also shut down server when done
+run_to 10 tests/margo-test-client $svr1 &> /dev/null 
+if [ $? -ne 0 ]; then
+    wait
+    exit 1
+fi
+
+#####################
+
+
+wait
+
+exit 0

--- a/tests/basic-prio.sh
+++ b/tests/basic-prio.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -x
+
+if [ -z $srcdir ]; then
+    echo srcdir variable not set.
+    exit 1
+fi
+source $srcdir/tests/test-util.sh
+
+# start 1 server with 2 second wait, 20s timeout, priority pool
+test_start_servers 1 2 20 prio_wait
+
+sleep 1
+
+#####################
+
+# run client test, which will also shut down server when done
+run_to 10 tests/margo-test-client $svr1 &> /dev/null 
+if [ $? -ne 0 ]; then
+    wait
+    exit 1
+fi
+
+#####################
+
+
+wait
+
+exit 0

--- a/tests/margo-test-server.c
+++ b/tests/margo-test-server.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -17,73 +17,81 @@
  * and then executes indefinitely.
  */
 
-struct options
-{
-    int single_pool_mode;
-    char *hostfile;
-    char *listen_addr;
+struct options {
+    int   single_pool_mode;
+    char* hostfile;
+    char* listen_addr;
+    char* pool_kind;
 };
 
-static void parse_args(int argc, char **argv, struct options *opts);
+static void parse_args(int argc, char** argv, struct options* opts);
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
-    hg_return_t hret;
-    margo_instance_id mid;
-    struct options opts;
+    hg_return_t            hret;
+    margo_instance_id      mid;
+    struct options         opts;
+    char                   json[256] = {0};
+    struct margo_init_info minfo     = {0};
+
+    minfo.json_config = json;
 
     parse_args(argc, argv, &opts);
 
+    /* If single pool mode, use the calling xstream to drive progress and
+     * execute handlers. If not, use a dedicated progress xstream for
+     * progress and handlers
+     */
+    if (opts.single_pool_mode)
+        sprintf(json,
+                "{\"argobots\":{\"pools\":[{\"name\":\"__primary__\", "
+                "\"kind\":\"%s\"}]}}",
+                opts.pool_kind);
+    else
+        sprintf(json,
+                "{\"argobots\":{\"pools\":[{ \"name\":\"__primary__\", "
+                "\"kind\":\"%s\" }, { \"name\":\"__progress__\", "
+                "\"kind\":\"%s\" }]}}",
+                opts.pool_kind, opts.pool_kind);
+
     /* actually start margo -- this step encapsulates the Mercury and
      * Argobots initialization and must precede their use */
-    /* If single pool mode, use the calling xstream to drive progress and
-     * execute handlers. If not, use a dedicated progress xstream and
-     * run handlers directly on the calling xstream
-     */
-    /***************************************/
-    if(opts.single_pool_mode)
-        mid = margo_init(opts.listen_addr, MARGO_SERVER_MODE, 0, -1);
-    else
-        mid = margo_init(opts.listen_addr, MARGO_SERVER_MODE, 1, 0);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
-        fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+    mid = margo_init_ext(opts.listen_addr, MARGO_SERVER_MODE, &minfo);
+    if (mid == MARGO_INSTANCE_NULL) {
+        fprintf(stderr, "Error: margo_init_ext()\n");
+        return (-1);
     }
 
     margo_set_log_level(mid, MARGO_LOG_TRACE);
 
-    if(opts.hostfile)
-    {
-        FILE *fp;
+    if (opts.hostfile) {
+        FILE*     fp;
         hg_addr_t addr_self;
-        char addr_self_string[128];
+        char      addr_self_string[128];
         hg_size_t addr_self_string_sz = 128;
 
         /* figure out what address this server is listening on */
         hret = margo_addr_self(mid, &addr_self);
-        if(hret != HG_SUCCESS)
-        {
+        if (hret != HG_SUCCESS) {
             fprintf(stderr, "Error: margo_addr_self()\n");
             margo_finalize(mid);
-            return(-1);
+            return (-1);
         }
-        hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz, addr_self);
-        if(hret != HG_SUCCESS)
-        {
+        hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz,
+                                    addr_self);
+        if (hret != HG_SUCCESS) {
             fprintf(stderr, "Error: margo_addr_to_string()\n");
             margo_addr_free(mid, addr_self);
             margo_finalize(mid);
-            return(-1);
+            return (-1);
         }
         margo_addr_free(mid, addr_self);
 
         fp = fopen(opts.hostfile, "w");
-        if(!fp)
-        {
+        if (!fp) {
             perror("fopen");
             margo_finalize(mid);
-            return(-1);
+            return (-1);
         }
 
         fprintf(fp, "%s", addr_self_string);
@@ -91,10 +99,9 @@ int main(int argc, char **argv)
     }
 
     /* register RPC */
-    MARGO_REGISTER(mid, "my_rpc", my_rpc_in_t, my_rpc_out_t, 
-        my_rpc_ult);
-    MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t, my_rpc_hang_out_t, 
-        my_rpc_hang_ult);
+    MARGO_REGISTER(mid, "my_rpc", my_rpc_in_t, my_rpc_out_t, my_rpc_ult);
+    MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t, my_rpc_hang_out_t,
+                   my_rpc_hang_ult);
 
     margo_enable_remote_shutdown(mid);
     /* NOTE: at this point this server ULT has two options.  It can wait on
@@ -113,49 +120,52 @@ int main(int argc, char **argv)
      */
     margo_wait_for_finalize(mid);
 
-    return(0);
+    return (0);
 }
 
-static void usage(int argc, char **argv)
+static void usage(int argc, char** argv)
 {
-    fprintf(stderr, "Usage: %s listen_address [-s] [-f filename]\n",
-        argv[0]);
-    fprintf(stderr, "   listen_address is the address or protocol for the server to use\n");
+    fprintf(stderr, "Usage: %s listen_address [-s] [-f filename]\n", argv[0]);
+    fprintf(
+        stderr,
+        "   listen_address is the address or protocol for the server to use\n");
     fprintf(stderr, "   [-s] for single pool mode\n");
     fprintf(stderr, "   [-f filename] to write the server address to a file\n");
+    fprintf(stderr, "   [-p pool kind] to specify kind of ABT pools to use\n");
     return;
 }
 
-
-static void parse_args(int argc, char **argv, struct options *opts)
+static void parse_args(int argc, char** argv, struct options* opts)
 {
     int opt;
-    
+
     memset(opts, 0, sizeof(*opts));
 
-    while((opt = getopt(argc, argv, "f:s")) != -1)
-    {
-        switch(opt)
-        {
-            case 's':
-                opts->single_pool_mode = 1;
-                break;
-            case 'f':
-                opts->hostfile = strdup(optarg);
-                break;
-            default: 
-                usage(argc, argv);
-                exit(EXIT_FAILURE);
+    while ((opt = getopt(argc, argv, "f:sp:")) != -1) {
+        switch (opt) {
+        case 's':
+            opts->single_pool_mode = 1;
+            break;
+        case 'f':
+            opts->hostfile = strdup(optarg);
+            break;
+        case 'p':
+            opts->pool_kind = strdup(optarg);
+            break;
+        default:
+            usage(argc, argv);
+            exit(EXIT_FAILURE);
         }
     }
 
-    if(optind >= argc)
-    {
+    if (optind >= argc) {
         usage(argc, argv);
         exit(EXIT_FAILURE);
     }
 
+    if (!opts->pool_kind) opts->pool_kind = strdup("fifo_wait");
+
     opts->listen_addr = strdup(argv[optind]);
-    
+
     return;
 }

--- a/tests/test-util-ded-pool.sh
+++ b/tests/test-util-ded-pool.sh
@@ -19,14 +19,14 @@ function test_start_servers ()
     nservers=${1:-4}
     startwait=${2:-15}
     maxtime=${3:-120}s
-    repfactor=${4:-0}
+    poolkind=${4:-fifo_wait}
     pid=$$
 
     # start daemons
     for i in `seq 1 $nservers`
     do
         hostfile=`mktemp`
-        $TIMEOUT --signal=9 ${maxtime} tests/margo-test-server na+sm:// -f $hostfile &
+        $TIMEOUT --signal=9 ${maxtime} tests/margo-test-server na+sm:// -f $hostfile -p $poolkind &
         if [ $? -ne 0 ]; then
             # TODO: this doesn't actually work; can't check return code of
             # something executing in background.  We have to rely on the

--- a/tests/test-util.sh
+++ b/tests/test-util.sh
@@ -19,14 +19,14 @@ function test_start_servers ()
     nservers=${1:-4}
     startwait=${2:-15}
     maxtime=${3:-120}s
-    repfactor=${4:-0}
+    poolkind=${4:-fifo_wait}
     pid=$$
 
     # start daemons
     for i in `seq 1 $nservers`
     do
         hostfile=`mktemp`
-        $TIMEOUT --signal=9 ${maxtime} tests/margo-test-server na+sm:// -s -f $hostfile &
+        $TIMEOUT --signal=9 ${maxtime} tests/margo-test-server na+sm:// -s -f $hostfile -p $poolkind &
         if [ $? -ne 0 ]; then
             # TODO: this doesn't actually work; can't check return code of
             # something executing in background.  We have to rely on the


### PR DESCRIPTION
This PR adds a new supported pool kind to the margo json, called "prio_wait".  It can be used in any place where "fifo_wait" would normally appear in the json.

This replaces the default pool implementation that margo uses with a custom one that will prioritize completing existing ULTs over starting new ones (in situations where both are eligible to execute).  Hypothetically this may help heavily oversubscribed servers make progress on in-flight RPCs faster, but we don't have measurements to support that hypothesis.