### PR TITLE
honor environment variables to enable diagnostics and profiling at run time

### DIFF
--- a/src/margo-diag.c
+++ b/src/margo-diag.c
@@ -357,6 +357,7 @@ void margo_diag_dump(margo_instance_id mid, const char* file, int uniquify)
     HASH_JEN(name, strlen(name),
              hash); /*record own address in the breadcrumb */
     fprintf(outfile, "#Addr Hash and Address Name: %lu,%s\n", hash, name);
+    free(name);
     fprintf(outfile, "# %s\n", ctime(&ltime));
     fprintf(outfile,
             "# Function Name, Average Time Per Call, Cumulative Time, "
@@ -430,6 +431,7 @@ void margo_profile_dump(margo_instance_id mid, const char* file, int uniquify)
              hash); /*record own address in the breadcrumb */
 
     fprintf(outfile, "%lu,%s\n", hash, name);
+    free(name);
 
     tmp_rpc = mid->registered_rpcs;
     while (tmp_rpc) {

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -344,6 +344,7 @@ margo_instance_id margo_init_ext(const char*                   address,
         // record own address in cache to be used in breadcrumb generation
         GET_SELF_ADDR_STR(mid, name);
         HASH_JEN(name, strlen(name), mid->self_addr_hash);
+        free(name);
 
         ret = ABT_thread_create(
             mid->progress_pool, __margo_sparkline_data_collection_fn, mid,
@@ -448,8 +449,12 @@ validate_and_complete_config(struct json_object*        _margo,
     }
 
     { // add or override enable_profiling
-        CONFIG_HAS_OR_CREATE(_margo, boolean, "enable_profiling", 0,
-                             "enable_profiling", val);
+        const char* margo_enable_profiling_str
+            = getenv("MARGO_ENABLE_PROFILING");
+        int margo_enable_profiling
+            = margo_enable_profiling_str ? atoi(margo_enable_profiling_str) : 0;
+        CONFIG_HAS_OR_CREATE(_margo, boolean, "enable_profiling",
+                             margo_enable_profiling, "enable_profiling", val);
         MARGO_TRACE(0, "enable_profiling = %s",
                     json_object_get_boolean(val) ? "true" : "false");
     }

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -455,8 +455,14 @@ validate_and_complete_config(struct json_object*        _margo,
     }
 
     { // add or override enable_diagnostics
-        CONFIG_HAS_OR_CREATE(_margo, boolean, "enable_diagnostics", 0,
-                             "enable_diagnostics", val);
+        const char* margo_enable_diagnostics_str
+            = getenv("MARGO_ENABLE_DIAGNOSTICS");
+        int margo_enable_diagnostics = margo_enable_diagnostics_str
+                                         ? atoi(margo_enable_diagnostics_str)
+                                         : 0;
+        CONFIG_HAS_OR_CREATE(_margo, boolean, "enable_diagnostics",
+                             margo_enable_diagnostics, "enable_diagnostics",
+                             val);
         MARGO_TRACE(0, "enable_diagnostics = %s",
                     json_object_get_boolean(val) ? "true" : "false");
     }


### PR DESCRIPTION
This PR makes it possible again to set the MARGO_ENABLE_DIAGNOSTICS and MARGO_ENABLE_PROFILING environment variables to enable those features at runtime without modifying the target application.

It also includes some minor memory leak fixes.

Fixes #75 

