### PR TITLE
Destroy timer on failed forwarding

### DIFF
--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -903,7 +903,14 @@ static hg_return_t margo_provider_iforward_internal(
             req->server_addr_hash); /*record server address in the breadcrumb */
     }
 
-    return HG_Forward(handle, margo_cb, (void*)req, in_struct);
+    hret = HG_Forward(handle, margo_cb, (void*)req, in_struct);
+    /* remove timer if HG_Forward failed */
+    if (hret != HG_SUCCESS && req->timer) {
+        __margo_timer_destroy(mid, req->timer);
+        free(req->timer);
+        req->timer = NULL;
+    }
+    return hret;
 }
 
 hg_return_t margo_provider_forward(uint16_t    provider_id,

--- a/tests/Makefile.subdir
+++ b/tests/Makefile.subdir
@@ -9,7 +9,8 @@ check_PROGRAMS += \
  tests/margo-test-sleep \
  tests/margo-test-server \
  tests/margo-test-client \
- tests/margo-test-client-timeout
+ tests/margo-test-client-timeout \
+ tests/margo-test-client-error
 
 TESTS += \
  tests/sleep.sh \
@@ -17,13 +18,15 @@ TESTS += \
  tests/basic-ded-pool.sh \
  tests/basic-prio.sh \
  tests/basic-ded-pool-prio.sh \
- tests/timeout.sh
+ tests/timeout.sh \
+ tests/error.sh
 
 EXTRA_DIST += \
  tests/sleep.sh \
  tests/basic.sh \
  tests/basic-ded-pool.sh \
  tests/timeout.sh \
+ tests/error.sh \
  tests/test-util.sh \
  tests/test-util-ded-pool.sh
 

--- a/tests/error.sh
+++ b/tests/error.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -x
+
+if [ -z $srcdir ]; then
+    echo srcdir variable not set.
+    exit 1
+fi
+
+if [ -z "$MKTEMP" ] ; then
+    echo expected MKTEMP variable defined to its respective command
+    exit 1
+fi
+
+source $srcdir/tests/test-util.sh
+
+TMPOUT=$($MKTEMP --tmpdir test-XXXXXX)
+
+# do not start server, and set dummy address
+svr1="na+sm://4661/0"
+
+sleep 1
+
+#####################
+
+# run client test
+run_to 10 tests/margo-test-client-error $svr1 &> $TMPOUT 
+if [ $? -ne 0 ]; then
+    wait
+    cat $TMPOUT
+    exit 1
+fi
+
+# check output; look for four "returned 10" to indicate HG_NODEV in the four
+# concurrent RPCs
+LINECOUNT=$(grep "returned HG_NODEV" $TMPOUT | wc -l) 
+if [ $LINECOUNT -ne 4 ]; then
+    wait
+    cat $TMPOUT
+    exit 1
+fi
+
+#####################
+
+rm -rf $TMPOUT
+exit 0

--- a/tests/margo-test-client-error.c
+++ b/tests/margo-test-client-error.c
@@ -1,0 +1,205 @@
+/*
+ * (C) 2015 The University of Chicago
+ * 
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+#include <mercury.h>
+#include <abt.h>
+#include <margo.h>
+
+#include "my-rpc.h"
+
+/* This is an example client program that issues 4 concurrent RPCs, each of
+ * which includes a bulk transfer driven by the server.
+ *
+ * Each client operation executes as an independent ULT in Argobots.
+ * The HG forward call is executed using asynchronous operations.
+ */
+
+struct run_my_rpc_args
+{
+    int val;
+    margo_instance_id mid;
+    hg_addr_t svr_addr;
+};
+
+static void run_my_rpc(void *_arg);
+
+static hg_id_t my_rpc_hang_id;
+
+int main(int argc, char **argv) 
+{
+    struct run_my_rpc_args args[4];
+    ABT_thread threads[4];
+    int i;
+    int ret;
+    hg_return_t hret;
+    ABT_xstream xstream;
+    ABT_pool pool;
+    margo_instance_id mid;
+    hg_addr_t svr_addr = HG_ADDR_NULL;
+    char proto[12] = {0};
+      
+    if(argc != 2)
+    {
+        fprintf(stderr, "Usage: ./client-timeout <server_addr>\n");
+        return(-1);
+    }
+   
+    /* initialize Mercury using the transport portion of the destination
+     * address (i.e., the part before the first : character if present)
+     */
+    for(i=0; i<11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
+        proto[i] = argv[1][i];
+
+    /* actually start margo -- margo_init() encapsulates the Mercury &
+     * Argobots initialization, so this step must precede their use. */
+    /* Use main process to drive progress (it will relinquish control to
+     * Mercury during blocking communication calls).  The rpc handler pool 
+     * is null in this example program because this is a pure client that 
+     * will not be servicing rpc requests.
+     */
+    /***************************************/
+    mid = margo_init(proto, MARGO_CLIENT_MODE, 0, 0);
+    if(mid == MARGO_INSTANCE_NULL)
+    {
+        fprintf(stderr, "Error: margo_init()\n");
+        return(-1);
+    }
+
+    /* retrieve current pool to use for ULT creation */
+    ret = ABT_xstream_self(&xstream);
+    if(ret != 0)
+    {
+        fprintf(stderr, "Error: ABT_xstream_self()\n");
+        return(-1);
+    }
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    if(ret != 0)
+    {
+        fprintf(stderr, "Error: ABT_xstream_get_main_pools()\n");
+        return(-1);
+    }
+
+    /* register RPCs */
+    my_rpc_hang_id = MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t, my_rpc_hang_out_t, 
+        NULL);
+
+    /* find addr for server */
+    hret = margo_addr_lookup(mid, argv[1], &svr_addr);
+    assert(hret == HG_SUCCESS);
+
+    for(i=0; i<4; i++)
+    {
+        args[i].val = i;
+        args[i].mid = mid;
+        args[i].svr_addr = svr_addr;
+
+        /* Each ult gets a pointer to an element of the array to use
+         * as input for the run_my_rpc() function.
+         */
+        ret = ABT_thread_create(pool, run_my_rpc, &args[i],
+            ABT_THREAD_ATTR_NULL, &threads[i]);
+        if(ret != 0)
+        {
+            fprintf(stderr, "Error: ABT_thread_create()\n");
+            return(-1);
+        }
+
+    }
+
+    /* yield to one of the threads */
+    ABT_thread_yield_to(threads[0]);
+
+    for(i=0; i<4; i++)
+    {
+        ret = ABT_thread_join(threads[i]);
+        if(ret != 0)
+        {
+            fprintf(stderr, "Error: ABT_thread_join()\n");
+            return(-1);
+        }
+        ret = ABT_thread_free(&threads[i]);
+        if(ret != 0)
+        {
+            fprintf(stderr, "Error: ABT_thread_join()\n");
+            return(-1);
+        }
+    }
+
+    margo_addr_free(mid, svr_addr);
+
+    /* shut down everything */
+    margo_finalize(mid);
+    
+    return(0);
+}
+
+static void run_my_rpc(void *_arg)
+{
+    struct run_my_rpc_args *arg = _arg;
+    hg_handle_t handle;
+    my_rpc_hang_in_t in;
+    my_rpc_hang_out_t out;
+    hg_return_t hret;
+    hg_size_t size;
+    void* buffer;
+
+    printf("ULT [%d] running.\n", arg->val);
+
+    /* allocate buffer for bulk transfer */
+    size = 512;
+    buffer = calloc(1, 512);
+    assert(buffer);
+    sprintf((char*)buffer, "Hello world!\n");
+
+    /* create handle */
+    hret = margo_create(arg->mid, arg->svr_addr, my_rpc_hang_id, &handle);
+    assert(hret == HG_SUCCESS);
+
+    /* register buffer for rdma/bulk access by server */
+    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, 
+        HG_BULK_READ_ONLY, &in.bulk_handle);
+    assert(hret == HG_SUCCESS);
+
+    /* Send rpc. Note that we are also transmitting the bulk handle in the
+     * input struct.  It was set above. 
+     */ 
+    in.input_val = arg->val;
+    /* call with 2 second timeout */
+    hret = margo_forward_timed(handle, &in, 2000.0);
+
+    if(hret == HG_SUCCESS)
+    {
+        /* decode response */
+        hret = margo_get_output(handle, &out);
+        assert(hret == HG_SUCCESS);
+        printf("Got response ret: %d\n", out.ret);
+        margo_free_output(handle, &out);
+    }
+    else if(hret == HG_NODEV)
+        printf("margo_forward returned HG_NODEV\n");
+    else
+        printf("margo_forward returned %d\n", hret);
+
+    /* clean up resources consumed by this rpc */
+    margo_bulk_free(in.bulk_handle);
+    margo_destroy(handle);
+    free(buffer);
+
+    printf("ULT [%d] done.\n", arg->val);
+
+    /* sleep 3s 
+     * This is waiting for the undeleted timer to expire 
+     * Timer is setted when above margo_forward_timed is called
+     * https://github.com/mochi-hpc/mochi-margo/issues/113
+     */
+    fprintf(stderr, "sleep 3s\n");
+    margo_thread_sleep(arg->mid, 3000);
+
+    return;
+}


### PR DESCRIPTION
## Desription

this PR is created for fix https://github.com/mochi-hpc/mochi-margo/issues/113 , and add test cases which this fix can resolved. 

this time added a case of communicating with a non-existent (=dummy address) server.

I tried to create a more realistic example with `na+sm` protocol, but it didn't work (please let me know if you can).

in `na+sm` protocol, if server is not exists, `HG_Forward` returns `HG_NODEV` and `margo_cb` is not called.

As I wrote in https://github.com/mochi-hpc/mochi-margo/issues/113 , timer is not removed if `margo_cb` is not called.

after that, timer is expired and call `HG_Cancel` with **already failed** request, it occurs segmentation fault.

To reproduce this, the timer needs to be expired after fails `HG_Forward` and before `margo_finalize`, so add `sleep 3s` in the end of `run_my_rpc`.

You can see this in the test-suite.log

```
===================================
   margo 0.9.2: ./test-suite.log
===================================

# TOTAL: 7
# PASS:  6
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: tests/error.sh
====================

+ '[' -z .. ']'
+ '[' -z mktemp ']'
+ source ../tests/test-util.sh
++ '[' -z timeout ']'
++ mktemp --tmpdir test-XXXXXX
+ TMPOUT=/tmp/test-uoHc8U
+ svr1=na+sm://4661/0
+ sleep 1
+ run_to 10 tests/margo-test-client-error na+sm://4661/0
+ '[' 139 -ne 0 ']'
+ wait
+ cat /tmp/test-uoHc8U
+ maxtime=10s
+ shift
+ timeout --signal=9 10s tests/margo-test-client-error na+sm://4661/0
sleep 3s
sleep 3s
sleep 3s
sleep 3s
timeout: the monitored command dumped core
../tests/test-util.sh: line 11: 15788 Segmentation fault      $TIMEOUT --signal=9 $maxtime "$@"
+ exit 1
FAIL tests/error.sh (exit status: 1)
```

