### PR TITLE
WIP: emit messages to stderr with details if Argobots environment variables not set

### DIFF
--- a/include/margo-util.h
+++ b/include/margo-util.h
@@ -21,6 +21,7 @@ extern "C" {
  * @return 0 in case of success, -1 if Argobots is already initialized
  */
 int margo_set_abt_mem_max_num_stacks(unsigned max_num_stacks);
+int margo_confirm_abt_mem_max_num_stacks(unsigned max_num_stacks);
 
 /**
  * @brief This function sets the ABT_THREAD_STACKSIZE
@@ -33,6 +34,7 @@ int margo_set_abt_mem_max_num_stacks(unsigned max_num_stacks);
  * @return 0 in case of success, -1 if Argobots is already initialized
  */
 int margo_set_abt_thread_stacksize(unsigned stacksize);
+int margo_confirm_abt_thread_stacksize(unsigned stacksize);
 
 #ifdef __cplusplus
 }

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -49,6 +49,8 @@ static int create_xstream_from_config(struct json_object* es_config,
 
 // Sets environment variables for Argobots
 static void set_argobots_environment_variables(struct json_object* config);
+// Confirms existing environment variables for Argobots
+static void confirm_argobots_environment_variables(struct json_object* config);
 
 // Shutdown logic for a margo instance
 static void remote_shutdown_ult(hg_handle_t handle);
@@ -178,9 +180,7 @@ margo_instance_id margo_init_ext(const char*                   address,
         ret              = ABT_mutex_create(&g_margo_num_instances_mtx);
         if (ret != 0) goto error;
     } else {
-        MARGO_WARNING(0,
-                      "Argobots was initialized externally, so margo_init_ext "
-                      "could not set Argobots environment variables");
+        confirm_argobots_environment_variables(config);
     }
 
     // instantiate pools
@@ -1357,6 +1357,18 @@ static int create_xstream_from_config(struct json_object* es_config,
     }
 
     return ABT_SUCCESS;
+}
+
+static void confirm_argobots_environment_variables(struct json_object* config)
+{
+    struct json_object* argobots = json_object_object_get(config, "argobots");
+    int                 abt_mem_max_num_stacks = json_object_get_int64(
+        json_object_object_get(argobots, "abt_mem_max_num_stacks"));
+    int abt_thread_stacksize = json_object_get_int64(
+        json_object_object_get(argobots, "abt_thread_stacksize"));
+
+    margo_confirm_abt_mem_max_num_stacks(abt_mem_max_num_stacks);
+    margo_confirm_abt_thread_stacksize(abt_thread_stacksize);
 }
 
 static void set_argobots_environment_variables(struct json_object* config)

--- a/src/margo-util.c
+++ b/src/margo-util.c
@@ -6,6 +6,23 @@
 #include "margo-util.h"
 #include <stdlib.h>
 #include <abt.h>
+#include "margo-instance.h"
+
+int margo_confirm_abt_mem_max_num_stacks(unsigned max_num_stacks)
+{
+    const char* abt_mem_max_num_stacks_str = getenv("ABT_MEM_MAX_NUM_STACKS");
+    if (!abt_mem_max_num_stacks_str
+        || atoi(abt_mem_max_num_stacks_str) != max_num_stacks) {
+        MARGO_ERROR(0,
+                    "Argobots was initialized externally, but the "
+                    "ABT_MEM_MAX_NUM_STACKS environment variable "
+                    "is not set to the value of %u expected by Margo",
+                    max_num_stacks);
+        return -1;
+    }
+
+    return 0;
+}
 
 int margo_set_abt_mem_max_num_stacks(unsigned max_num_stacks)
 {
@@ -13,6 +30,22 @@ int margo_set_abt_mem_max_num_stacks(unsigned max_num_stacks)
     char env_str[64];
     sprintf(env_str, "%d", max_num_stacks);
     setenv("ABT_MEM_MAX_NUM_STACKS", env_str, 1);
+    return 0;
+}
+
+int margo_confirm_abt_thread_stacksize(unsigned stacksize)
+{
+    const char* abt_thread_stacksize_str = getenv("ABT_THREAD_STACKSIZE");
+    if (!abt_thread_stacksize_str
+        || atoi(abt_thread_stacksize_str) != stacksize) {
+        MARGO_ERROR(0,
+                    "Argobots was initialized externally, but the "
+                    "ABT_THREAD_STACKSIZE environment variable is "
+                    "not set to the value of %u expected by Margo",
+                    stacksize);
+        return -1;
+    }
+
     return 0;
 }
 

--- a/tests/Makefile.subdir
+++ b/tests/Makefile.subdir
@@ -6,6 +6,7 @@ TESTS_ENVIRONMENT += \
 if BUILD_TESTS
 check_PROGRAMS += \
  tests/margo-test-init-ext \
+ tests/margo-test-init-after-abt \
  tests/margo-test-sleep \
  tests/margo-test-server \
  tests/margo-test-client \
@@ -19,7 +20,8 @@ TESTS += \
  tests/basic-prio.sh \
  tests/basic-ded-pool-prio.sh \
  tests/timeout.sh \
- tests/error.sh
+ tests/error.sh \
+ tests/margo-test-init-after-abt
 
 EXTRA_DIST += \
  tests/sleep.sh \

--- a/tests/margo-test-init-after-abt.c
+++ b/tests/margo-test-init-after-abt.c
@@ -1,0 +1,29 @@
+/*
+ * (C) 2015 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <margo.h>
+#include <margo-logging.h>
+
+int main(int argc, char **argv)
+{
+    margo_instance_id mid;
+    struct margo_init_info args = { 0 };
+
+    ABT_init(0, NULL);
+
+    mid = margo_init_ext("na+sm", MARGO_CLIENT_MODE, &args);
+    assert(mid);
+
+    margo_finalize(mid);
+
+    ABT_finalize();
+
+    return 0;
+}


### PR DESCRIPTION
During a normal margo_init() cycle, Margo will set a few Argobots parameters to make sure that sufficient memory is available for typical Mochi use cases.

If ABT_init() is called before margo_init(), however, Margo doesn't have an opportunity to set these values.  They cannot be modified once Argobots is initialized.

This PR  will cause Margo to emit the following in this situation if the desired environment variables have not been set externally:

```
[error] Argobots was initialized externally, but the ABT_MEM_MAX_NUM_STACKS environment variable is not set to the value of 8 expected by Margo
[error] Argobots was initialized externally, but the ABT_THREAD_STACKSIZE environment variable is not set to the value of 2097152 expected by Margo
```
Execution then continues as normal.  This is intended to just make the problem more obvious.

There are some options for how to avoid this case in the first place:
* Have SSG set default values for these if they aren't already present in the env (this will be sufficient in most cases; the messages will then just be emitted if the margo json configuration disagrees)
* Investigate the possibility of having Argobots permit runtime modification of these values
* ???


