### PR TITLE
clang format remaining aux files

### DIFF
--- a/examples/composition/composed-benchmark.c
+++ b/examples/composition/composed-benchmark.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -12,59 +12,59 @@
 
 #include "composed-client-lib.h"
 
-static hg_id_t my_rpc_shutdown_id;
-static void* buffer;
-static hg_size_t buffer_sz = 8*1024*1024;
+static hg_id_t   my_rpc_shutdown_id;
+static void*     buffer;
+static hg_size_t buffer_sz = 8 * 1024 * 1024;
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
-    int i;
-    int ret;
+    int               i;
+    int               ret;
     margo_instance_id mid;
-    hg_return_t hret;
-    hg_addr_t delegator_svr_addr = HG_ADDR_NULL;
-    hg_addr_t data_xfer_svr_addr = HG_ADDR_NULL;
-    hg_handle_t handle;
-    char *proto;
-    char *colon;
-    int iterations;
-    double start, end, t1, t2, avg, min=0, max=0;
-  
-    if(argc != 4)
-    {
-        fprintf(stderr, "Usage: ./client <delegator_svr_addr> <data_xfer_svr_addr> <iterations>\n");
-        return(-1);
+    hg_return_t       hret;
+    hg_addr_t         delegator_svr_addr = HG_ADDR_NULL;
+    hg_addr_t         data_xfer_svr_addr = HG_ADDR_NULL;
+    hg_handle_t       handle;
+    char*             proto;
+    char*             colon;
+    int               iterations;
+    double            start, end, t1, t2, avg, min = 0, max = 0;
+
+    if (argc != 4) {
+        fprintf(stderr,
+                "Usage: ./client <delegator_svr_addr> <data_xfer_svr_addr> "
+                "<iterations>\n");
+        return (-1);
     }
 
     ret = sscanf(argv[3], "%d", &iterations);
     assert(ret == 1);
-       
+
     /* initialize Mercury using the transport portion of the destination
      * address (i.e., the part before the first : character if present)
      */
     proto = strdup(argv[1]);
     assert(proto);
     colon = strchr(proto, ':');
-    if(colon)
-        *colon = '\0';
+    if (colon) *colon = '\0';
 
-    /* TODO: this is a hack for now; I don't really want this to operate in server mode,
-     * but it seems like it needs to for now for sub-service to be able to get back to it
+    /* TODO: this is a hack for now; I don't really want this to operate in
+     * server mode, but it seems like it needs to for now for sub-service to be
+     * able to get back to it
      */
     /* actually start margo */
     /***************************************/
     mid = margo_init(proto, MARGO_SERVER_MODE, 0, -1);
     free(proto);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
     margo_diag_start(mid);
 
     /* register core RPC */
-    my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc",
-        void, void, NULL);
+    my_rpc_shutdown_id
+        = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
     /* register service APIs */
     data_xfer_register_client(mid);
     composed_register_client(mid);
@@ -78,49 +78,44 @@ int main(int argc, char **argv)
     buffer = calloc(1, buffer_sz);
     assert(buffer);
 
-    /* TODO: this is where benchmark timing would go, probably with iterations */
+    /* TODO: this is where benchmark timing would go, probably with iterations
+     */
     /***************************************************************************/
 
     sleep(3);
     printf("# DBG: starting data_xfer_read() benchmark.\n");
     start = ABT_get_wtime();
-    for(i=0; i<iterations; i++)
-    {
+    for (i = 0; i < iterations; i++) {
         t1 = ABT_get_wtime();
         data_xfer_read(mid, data_xfer_svr_addr, buffer, buffer_sz);
         t2 = ABT_get_wtime();
-        if(min == 0 || t2-t1<min)
-            min = t2-t1;
-        if(max == 0 || t2-t1>max)
-            max = t2-t1;
+        if (min == 0 || t2 - t1 < min) min = t2 - t1;
+        if (max == 0 || t2 - t1 > max) max = t2 - t1;
     }
     end = ABT_get_wtime();
-    avg = (end-start)/((double)iterations);
+    avg = (end - start) / ((double)iterations);
     printf("# DBG:    ... DONE.\n");
     printf("# <op> <min> <avg> <max>\n");
     printf("direct\t%f\t%f\t%f\n", min, avg, max);
-    
+
     sleep(3);
 
     printf("# DBG: starting composed_read() benchmark.\n");
     start = ABT_get_wtime();
-    for(i=0; i<iterations; i++)
-    {
+    for (i = 0; i < iterations; i++) {
         t1 = ABT_get_wtime();
         composed_read(mid, delegator_svr_addr, buffer, buffer_sz, argv[2]);
         t2 = ABT_get_wtime();
-        if(min == 0 || t2-t1<min)
-            min = t2-t1;
-        if(max == 0 || t2-t1>max)
-            max = t2-t1;
+        if (min == 0 || t2 - t1 < min) min = t2 - t1;
+        if (max == 0 || t2 - t1 > max) max = t2 - t1;
     }
     end = ABT_get_wtime();
-    avg = (end-start)/((double)iterations);
+    avg = (end - start) / ((double)iterations);
     printf("# DBG:    ... DONE.\n");
     printf("# <op> <min> <avg> <max>\n");
     printf("composed\t%f\t%f\t%f\n", min, avg, max);
     printf("# DBG:    ... DONE.\n");
-    
+
     /***************************************************************************/
 
     /* send rpc(s) to shut down server(s) */
@@ -131,11 +126,11 @@ int main(int argc, char **argv)
     hret = margo_forward(handle, NULL);
     assert(hret == HG_SUCCESS);
     margo_destroy(handle);
-    if(strcmp(argv[1], argv[2]))
-    {
+    if (strcmp(argv[1], argv[2])) {
         sleep(3);
         printf("Shutting down data_xfer server.\n");
-        hret = margo_create(mid, data_xfer_svr_addr, my_rpc_shutdown_id, &handle);
+        hret = margo_create(mid, data_xfer_svr_addr, my_rpc_shutdown_id,
+                            &handle);
         assert(hret == HG_SUCCESS);
         hret = margo_forward(handle, NULL);
         assert(hret == HG_SUCCESS);
@@ -150,5 +145,5 @@ int main(int argc, char **argv)
     margo_finalize(mid);
     free(buffer);
 
-    return(0);
+    return (0);
 }

--- a/examples/composition/composed-client-lib.c
+++ b/examples/composition/composed-client-lib.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -22,42 +22,46 @@ static hg_id_t data_xfer_read_id = -1;
 int composed_register_client(margo_instance_id mid)
 {
 
-	delegator_read_id = MARGO_REGISTER(mid, "delegator_read", 
-        delegator_read_in_t, delegator_read_out_t, NULL);
+    delegator_read_id = MARGO_REGISTER(
+        mid, "delegator_read", delegator_read_in_t, delegator_read_out_t, NULL);
 
-    return(0);
+    return (0);
 }
 
 int data_xfer_register_client(margo_instance_id mid)
 {
 
-	data_xfer_read_id = MARGO_REGISTER(mid, "data_xfer_read", 
-        data_xfer_read_in_t, data_xfer_read_out_t, NULL);
+    data_xfer_read_id = MARGO_REGISTER(
+        mid, "data_xfer_read", data_xfer_read_in_t, data_xfer_read_out_t, NULL);
 
-    return(0);
+    return (0);
 }
 
-void composed_read(margo_instance_id mid, hg_addr_t svr_addr, void *buffer, hg_size_t buffer_sz, char *data_xfer_svc_addr_string)
+void composed_read(margo_instance_id mid,
+                   hg_addr_t         svr_addr,
+                   void*             buffer,
+                   hg_size_t         buffer_sz,
+                   char*             data_xfer_svc_addr_string)
 {
-    hg_handle_t handle;
-    delegator_read_in_t in;
+    hg_handle_t          handle;
+    delegator_read_in_t  in;
     delegator_read_out_t out;
-    hg_return_t hret;
+    hg_return_t          hret;
 
     /* create handle */
     hret = margo_create(mid, svr_addr, delegator_read_id, &handle);
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(mid, 1, &buffer, &buffer_sz, 
-        HG_BULK_WRITE_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &buffer_sz, HG_BULK_WRITE_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     in.data_xfer_svc_addr = data_xfer_svc_addr_string;
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     hret = margo_forward(handle, &in);
     assert(hret == HG_SUCCESS);
 
@@ -73,37 +77,41 @@ void composed_read(margo_instance_id mid, hg_addr_t svr_addr, void *buffer, hg_s
     return;
 }
 
-void data_xfer_read(margo_instance_id mid, hg_addr_t svr_addr, void *buffer, hg_size_t buffer_sz)
+void data_xfer_read(margo_instance_id mid,
+                    hg_addr_t         svr_addr,
+                    void*             buffer,
+                    hg_size_t         buffer_sz)
 {
-    hg_handle_t handle;
-    data_xfer_read_in_t in;
+    hg_handle_t          handle;
+    data_xfer_read_in_t  in;
     data_xfer_read_out_t out;
-    hg_return_t hret;
-    hg_addr_t addr_self;
-    char addr_self_string[128];
-    hg_size_t addr_self_string_sz = 128;
+    hg_return_t          hret;
+    hg_addr_t            addr_self;
+    char                 addr_self_string[128];
+    hg_size_t            addr_self_string_sz = 128;
 
     /* create handle */
     hret = margo_create(mid, svr_addr, data_xfer_read_id, &handle);
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(mid, 1, &buffer, &buffer_sz, 
-        HG_BULK_WRITE_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &buffer_sz, HG_BULK_WRITE_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* figure out local address */
     hret = margo_addr_self(mid, &addr_self);
     assert(hret == HG_SUCCESS);
 
-    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz, addr_self);
+    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz,
+                                addr_self);
     assert(hret == HG_SUCCESS);
 
     in.client_addr = addr_self_string;
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     hret = margo_forward(handle, &in);
     assert(hret == HG_SUCCESS);
 

--- a/examples/composition/composed-client-lib.h
+++ b/examples/composition/composed-client-lib.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -9,10 +9,17 @@
 
 #include <margo.h>
 
-int composed_register_client(margo_instance_id mid);
-void composed_read(margo_instance_id mid, hg_addr_t svr_addr, void* buffer, hg_size_t buffer_sz, char *data_xfer_svc_addr_string);
+int  composed_register_client(margo_instance_id mid);
+void composed_read(margo_instance_id mid,
+                   hg_addr_t         svr_addr,
+                   void*             buffer,
+                   hg_size_t         buffer_sz,
+                   char*             data_xfer_svc_addr_string);
 
-int data_xfer_register_client(margo_instance_id mid);
-void data_xfer_read(margo_instance_id mid, hg_addr_t svr_addr, void* buffer, hg_size_t buffer_sz);
+int  data_xfer_register_client(margo_instance_id mid);
+void data_xfer_read(margo_instance_id mid,
+                    hg_addr_t         svr_addr,
+                    void*             buffer,
+                    hg_size_t         buffer_sz);
 
 #endif /* __COMPOSED_CLIENT_LIB */

--- a/examples/composition/composed-svc-daemon.c
+++ b/examples/composition/composed-svc-daemon.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -25,10 +25,10 @@
 
 static void my_rpc_shutdown_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid;
 
-    //printf("Got RPC request to shutdown\n");
+    // printf("Got RPC request to shutdown\n");
 
     mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
@@ -49,23 +49,23 @@ static void my_rpc_shutdown_ult(hg_handle_t handle)
 }
 DEFINE_MARGO_RPC_HANDLER(my_rpc_shutdown_ult)
 
-
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid;
-    hg_addr_t addr_self;
-    char addr_self_string[128];
-    hg_size_t addr_self_string_sz = 128;
-    ABT_pool handler_pool;
-    char* svc_list;
-    char* svc;
+    hg_addr_t         addr_self;
+    char              addr_self_string[128];
+    hg_size_t         addr_self_string_sz = 128;
+    ABT_pool          handler_pool;
+    char*             svc_list;
+    char*             svc;
 
-    if(argc != 3)
-    {
-        fprintf(stderr, "Usage: ./server <listen_addr> <comma_separated_service_list>\n");
+    if (argc != 3) {
+        fprintf(
+            stderr,
+            "Usage: ./server <listen_addr> <comma_separated_service_list>\n");
         fprintf(stderr, "Example: ./server na+sm:// delegator,data-xfer\n");
-        return(-1);
+        return (-1);
     }
 
     svc_list = strdup(argv[2]);
@@ -76,28 +76,26 @@ int main(int argc, char **argv)
     /* Use the calling xstream to drive progress and execute handlers. */
     /***************************************/
     mid = margo_init(argv[1], MARGO_SERVER_MODE, 0, -1);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
     margo_diag_start(mid);
 
     /* figure out what address this server is listening on */
     hret = margo_addr_self(mid, &addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_self()\n");
         margo_finalize(mid);
-        return(-1);
+        return (-1);
     }
-    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz, addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz,
+                                addr_self);
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_to_string()\n");
         margo_addr_free(mid, addr_self);
         margo_finalize(mid);
-        return(-1);
+        return (-1);
     }
     margo_addr_free(mid, addr_self);
 
@@ -113,17 +111,12 @@ int main(int argc, char **argv)
 
     margo_get_handler_pool(mid, &handler_pool);
     svc = strtok(svc_list, ",");
-    while(svc)
-    {
-        if(!strcmp(svc, "data-xfer"))
-        {
+    while (svc) {
+        if (!strcmp(svc, "data-xfer")) {
             data_xfer_service_register(mid, handler_pool, 0);
-        }
-        else if(!strcmp(svc, "delegator"))
-        {
+        } else if (!strcmp(svc, "delegator")) {
             delegator_service_register(mid, handler_pool, 0);
-        }
-        else
+        } else
             assert(0);
 
         svc = strtok(NULL, ",");
@@ -146,5 +139,5 @@ int main(int argc, char **argv)
     svc2_deregister(mid, *handler_pool, 3);
 #endif
 
-    return(0);
+    return (0);
 }

--- a/examples/composition/data-xfer-proto.h
+++ b/examples/composition/data-xfer-proto.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -12,7 +12,6 @@
 
 MERCURY_GEN_PROC(data_xfer_read_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(data_xfer_read_in_t,
-    ((hg_string_t)(client_addr))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((hg_string_t)(client_addr))((hg_bulk_t)(bulk_handle)))
 
 #endif /* __DATA_XFER_PROTO */

--- a/examples/composition/data-xfer-service.c
+++ b/examples/composition/data-xfer-service.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -9,18 +9,18 @@
 #include "data-xfer-proto.h"
 #include "data-xfer-service.h"
 
-static hg_size_t g_buffer_size = 8*1024*1024;
-static void *g_buffer;
+static hg_size_t g_buffer_size = 8 * 1024 * 1024;
+static void*     g_buffer;
 static hg_bulk_t g_buffer_bulk_handle;
 
 static void data_xfer_read_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    data_xfer_read_out_t out;
-    data_xfer_read_in_t in;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
-    hg_addr_t client_addr;
+    hg_return_t           hret;
+    data_xfer_read_out_t  out;
+    data_xfer_read_in_t   in;
+    const struct hg_info* hgi;
+    margo_instance_id     mid;
+    hg_addr_t             client_addr;
 #if 0
     ABT_thread my_ult;
     ABT_xstream my_xstream; 
@@ -44,22 +44,19 @@ static void data_xfer_read_ult(hg_handle_t handle)
 
     out.ret = 0;
 
-    if(!in.client_addr)
+    if (!in.client_addr)
         client_addr = hgi->addr;
-    else
-    {
+    else {
         hret = margo_addr_lookup(mid, in.client_addr, &client_addr);
         assert(hret == HG_SUCCESS);
     }
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PUSH,
-        client_addr, in.bulk_handle, 0,
-        g_buffer_bulk_handle, 0, g_buffer_size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PUSH, client_addr, in.bulk_handle,
+                               0, g_buffer_bulk_handle, 0, g_buffer_size);
     assert(hret == HG_SUCCESS);
 
-    if(in.client_addr)
-        margo_addr_free(mid, client_addr);
+    if (in.client_addr) margo_addr_free(mid, client_addr);
 
     margo_free_input(handle, &in);
 
@@ -72,7 +69,9 @@ static void data_xfer_read_ult(hg_handle_t handle)
 }
 DEFINE_MARGO_RPC_HANDLER(data_xfer_read_ult)
 
-int data_xfer_service_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)
+int data_xfer_service_register(margo_instance_id mid,
+                               ABT_pool          pool,
+                               uint32_t          provider_id)
 {
     hg_return_t hret;
 
@@ -81,19 +80,21 @@ int data_xfer_service_register(margo_instance_id mid, ABT_pool pool, uint32_t pr
     assert(g_buffer);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &g_buffer,
-        &g_buffer_size, HG_BULK_READ_ONLY, &g_buffer_bulk_handle);
+    hret = margo_bulk_create(mid, 1, &g_buffer, &g_buffer_size,
+                             HG_BULK_READ_ONLY, &g_buffer_bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* register RPC handler */
-    MARGO_REGISTER_PROVIDER(mid, "data_xfer_read", 
-        data_xfer_read_in_t, data_xfer_read_out_t, 
-        data_xfer_read_ult, provider_id, pool);
+    MARGO_REGISTER_PROVIDER(mid, "data_xfer_read", data_xfer_read_in_t,
+                            data_xfer_read_out_t, data_xfer_read_ult,
+                            provider_id, pool);
 
-    return(0);
+    return (0);
 }
 
-void data_xfer_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)
+void data_xfer_deregister(margo_instance_id mid,
+                          ABT_pool          pool,
+                          uint32_t          provider_id)
 {
     margo_bulk_free(g_buffer_bulk_handle);
     free(g_buffer);

--- a/examples/composition/data-xfer-service.h
+++ b/examples/composition/data-xfer-service.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -9,7 +9,11 @@
 
 #include <margo.h>
 
-int data_xfer_service_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
-void data_xfer_service_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
+int  data_xfer_service_register(margo_instance_id mid,
+                                ABT_pool          pool,
+                                uint32_t          provider_id);
+void data_xfer_service_deregister(margo_instance_id mid,
+                                  ABT_pool          pool,
+                                  uint32_t          provider_id);
 
 #endif /* __DATA_XFER_SERVICE */

--- a/examples/composition/delegator-proto.h
+++ b/examples/composition/delegator-proto.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -12,7 +12,6 @@
 
 MERCURY_GEN_PROC(delegator_read_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(delegator_read_in_t,
-    ((hg_string_t)(data_xfer_svc_addr))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((hg_string_t)(data_xfer_svc_addr))((hg_bulk_t)(bulk_handle)))
 
 #endif /* __DELEGATOR_PROTO */

--- a/examples/composition/delegator-service.c
+++ b/examples/composition/delegator-service.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -14,18 +14,18 @@ static hg_id_t g_data_xfer_read_id = -1;
 
 static void delegator_read_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    delegator_read_out_t out;
-    delegator_read_in_t in;
-    data_xfer_read_in_t in_relay;
-    data_xfer_read_out_t out_relay;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
-    hg_addr_t data_xfer_svc_addr;
+    hg_return_t           hret;
+    delegator_read_out_t  out;
+    delegator_read_in_t   in;
+    data_xfer_read_in_t   in_relay;
+    data_xfer_read_out_t  out_relay;
+    const struct hg_info* hgi;
+    margo_instance_id     mid;
+    hg_addr_t             data_xfer_svc_addr;
 
     hg_handle_t handle_relay;
-    char client_addr_string[64];
-    hg_size_t client_addr_string_sz = 64;
+    char        client_addr_string[64];
+    hg_size_t   client_addr_string_sz = 64;
 #if 0
     ABT_thread my_ult;
     ABT_xstream my_xstream; 
@@ -51,17 +51,19 @@ static void delegator_read_ult(hg_handle_t handle)
 
     hret = margo_addr_lookup(mid, in.data_xfer_svc_addr, &data_xfer_svc_addr);
     assert(hret == HG_SUCCESS);
-    
+
     /* relay to microservice */
-    hret = margo_create(mid, data_xfer_svc_addr, g_data_xfer_read_id, &handle_relay);
+    hret = margo_create(mid, data_xfer_svc_addr, g_data_xfer_read_id,
+                        &handle_relay);
     assert(hret == HG_SUCCESS);
     /* pass through bulk handle */
-    in_relay.bulk_handle = in.bulk_handle; 
+    in_relay.bulk_handle = in.bulk_handle;
     /* get addr of client to relay to data_xfer service */
-    hret = margo_addr_to_string(mid, client_addr_string, &client_addr_string_sz, hgi->addr);
+    hret = margo_addr_to_string(mid, client_addr_string, &client_addr_string_sz,
+                                hgi->addr);
     assert(hret == HG_SUCCESS);
     in_relay.client_addr = client_addr_string;
-    hret = margo_forward(handle_relay, &in_relay);
+    hret                 = margo_forward(handle_relay, &in_relay);
     assert(hret == HG_SUCCESS);
 
     hret = margo_get_output(handle_relay, &out_relay);
@@ -81,24 +83,28 @@ static void delegator_read_ult(hg_handle_t handle)
 }
 DEFINE_MARGO_RPC_HANDLER(delegator_read_ult)
 
-int delegator_service_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)
+int delegator_service_register(margo_instance_id mid,
+                               ABT_pool          pool,
+                               uint32_t          provider_id)
 {
     /* register client-side of function to relay */
-    /* NOTE: this RPC may already be registered if this process has already registered a
-     * data-xfer service
+    /* NOTE: this RPC may already be registered if this process has already
+     * registered a data-xfer service
      */
-	g_data_xfer_read_id = MARGO_REGISTER(mid, "data_xfer_read",
-        data_xfer_read_in_t, data_xfer_read_out_t, NULL);
+    g_data_xfer_read_id = MARGO_REGISTER(
+        mid, "data_xfer_read", data_xfer_read_in_t, data_xfer_read_out_t, NULL);
 
     /* register RPC handler */
-    MARGO_REGISTER_PROVIDER(mid, "delegator_read", 
-        delegator_read_in_t, delegator_read_out_t, 
-        delegator_read_ult, provider_id, pool);
+    MARGO_REGISTER_PROVIDER(mid, "delegator_read", delegator_read_in_t,
+                            delegator_read_out_t, delegator_read_ult,
+                            provider_id, pool);
 
-    return(0);
+    return (0);
 }
 
-void delegator_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)
+void delegator_deregister(margo_instance_id mid,
+                          ABT_pool          pool,
+                          uint32_t          provider_id)
 {
     /* TODO: undo what was done in delegator_register() */
     return;

--- a/examples/composition/delegator-service.h
+++ b/examples/composition/delegator-service.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -9,7 +9,11 @@
 
 #include <margo.h>
 
-int delegator_service_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
-void delegator_service_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
+int  delegator_service_register(margo_instance_id mid,
+                                ABT_pool          pool,
+                                uint32_t          provider_id);
+void delegator_service_deregister(margo_instance_id mid,
+                                  ABT_pool          pool,
+                                  uint32_t          provider_id);
 
 #endif /* __DELEGATOR_SERVICE */

--- a/examples/margo-example-client.c
+++ b/examples/margo-example-client.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -20,47 +20,44 @@
  * The HG forward call is executed using asynchronous operations.
  */
 
-struct run_my_rpc_args
-{
-    int val;
+struct run_my_rpc_args {
+    int               val;
     margo_instance_id mid;
-    hg_addr_t svr_addr;
+    hg_addr_t         svr_addr;
 };
 
-static void run_my_rpc(void *_arg);
+static void run_my_rpc(void* _arg);
 
 static hg_id_t my_rpc_id;
 static hg_id_t my_rpc_shutdown_id;
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
     struct run_my_rpc_args args[4];
-    ABT_thread threads[4];
-    int i;
-    int ret;
-    hg_return_t hret;
-    ABT_xstream xstream;
-    ABT_pool pool;
-    margo_instance_id mid;
-    hg_addr_t svr_addr = HG_ADDR_NULL;
-    hg_handle_t handle;
-    char *proto;
-    char *colon;
-  
-    if(argc != 2)
-    {
+    ABT_thread             threads[4];
+    int                    i;
+    int                    ret;
+    hg_return_t            hret;
+    ABT_xstream            xstream;
+    ABT_pool               pool;
+    margo_instance_id      mid;
+    hg_addr_t              svr_addr = HG_ADDR_NULL;
+    hg_handle_t            handle;
+    char*                  proto;
+    char*                  colon;
+
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./client <server_addr>\n");
-        return(-1);
+        return (-1);
     }
-       
+
     /* initialize Mercury using the transport portion of the destination
      * address (i.e., the part before the first : character if present)
      */
     proto = strdup(argv[1]);
     assert(proto);
     colon = strchr(proto, ':');
-    if(colon)
-        *colon = '\0';
+    if (colon) *colon = '\0';
 
     /* actually start margo -- margo_init() encapsulates the Mercury &
      * Argobots initialization, so this step must precede their use. */
@@ -72,70 +69,62 @@ int main(int argc, char **argv)
     /***************************************/
     mid = margo_init(proto, MARGO_CLIENT_MODE, 0, 0);
     free(proto);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
     // margo_diag_start(mid);
 
     /* retrieve current pool to use for ULT creation */
     ret = ABT_xstream_self(&xstream);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_self()\n");
-        return(-1);
+        return (-1);
     }
     ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_get_main_pools()\n");
-        return(-1);
+        return (-1);
     }
 
     /* register RPC */
-	my_rpc_id = MARGO_REGISTER(mid, "my_rpc", my_rpc_in_t, my_rpc_out_t, NULL);
-	my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
+    my_rpc_id = MARGO_REGISTER(mid, "my_rpc", my_rpc_in_t, my_rpc_out_t, NULL);
+    my_rpc_shutdown_id
+        = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
 
     /* find addr for server */
     hret = margo_addr_lookup(mid, argv[1], &svr_addr);
     assert(hret == HG_SUCCESS);
 
-    for(i=0; i<4; i++)
-    {
-        args[i].val = i;
-        args[i].mid = mid;
+    for (i = 0; i < 4; i++) {
+        args[i].val      = i;
+        args[i].mid      = mid;
         args[i].svr_addr = svr_addr;
 
         /* Each ult gets a pointer to an element of the array to use
          * as input for the run_my_rpc() function.
          */
         ret = ABT_thread_create(pool, run_my_rpc, &args[i],
-            ABT_THREAD_ATTR_NULL, &threads[i]);
-        if(ret != 0)
-        {
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_create()\n");
-            return(-1);
+            return (-1);
         }
-
     }
 
     /* yield to one of the threads */
     ABT_thread_yield_to(threads[0]);
 
-    for(i=0; i<4; i++)
-    {
+    for (i = 0; i < 4; i++) {
         ret = ABT_thread_join(threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
         ret = ABT_thread_free(&threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
     }
 
@@ -155,23 +144,23 @@ int main(int argc, char **argv)
     // margo_diag_dump(mid, "-", 0);
     margo_finalize(mid);
 
-    return(0);
+    return (0);
 }
 
-static void run_my_rpc(void *_arg)
+static void run_my_rpc(void* _arg)
 {
-    struct run_my_rpc_args *arg = _arg;
-    hg_handle_t handle;
-    my_rpc_in_t in;
-    my_rpc_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    struct run_my_rpc_args* arg = _arg;
+    hg_handle_t             handle;
+    my_rpc_in_t             in;
+    my_rpc_out_t            out;
+    hg_return_t             hret;
+    hg_size_t               size;
+    void*                   buffer;
 
     printf("ULT [%d] running.\n", arg->val);
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -181,15 +170,15 @@ static void run_my_rpc(void *_arg)
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = arg->val;
-    hret = margo_forward(handle, &in);
+    hret         = margo_forward(handle, &in);
     assert(hret == HG_SUCCESS);
 
     /* decode response */
@@ -207,4 +196,3 @@ static void run_my_rpc(void *_arg)
     printf("ULT [%d] done.\n", arg->val);
     return;
 }
-

--- a/examples/margo-example-server-multihome.c
+++ b/examples/margo-example-server-multihome.c
@@ -17,20 +17,19 @@
  * and then executes indefinitely.
  */
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid1, mid2;
-    hg_addr_t addr_self;
-    char addr_self_string1[128];
-    char addr_self_string2[128];
-    hg_size_t addr_self_string_sz = 128;
+    hg_addr_t         addr_self;
+    char              addr_self_string1[128];
+    char              addr_self_string2[128];
+    hg_size_t         addr_self_string_sz = 128;
 
-    if(argc != 3)
-    {
+    if (argc != 3) {
         fprintf(stderr, "Usage: ./server <listen_addr1> <listen_addr2>\n");
         fprintf(stderr, "Example: ./server na+sm:// ofi+tcp://\n");
-        return(-1);
+        return (-1);
     }
 
     /* Start two margo instances.  Each uses it's own dedicated progress
@@ -39,58 +38,54 @@ int main(int argc, char **argv)
 
     /***************************************/
     mid1 = margo_init(argv[1], MARGO_SERVER_MODE, 1, -1);
-    if(mid1 == MARGO_INSTANCE_NULL)
-    {
+    if (mid1 == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
     mid2 = margo_init(argv[2], MARGO_SERVER_MODE, 1, -1);
-    if(mid2 == MARGO_INSTANCE_NULL)
-    {
+    if (mid2 == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
 
     /* figure out first listening addr */
     hret = margo_addr_self(mid1, &addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_self()\n");
         margo_finalize(mid1);
-        return(-1);
+        return (-1);
     }
     addr_self_string_sz = 128;
-    hret = margo_addr_to_string(mid1, addr_self_string1, &addr_self_string_sz, addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    hret = margo_addr_to_string(mid1, addr_self_string1, &addr_self_string_sz,
+                                addr_self);
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_to_string()\n");
         margo_addr_free(mid1, addr_self);
         margo_finalize(mid1);
-        return(-1);
+        return (-1);
     }
     margo_addr_free(mid1, addr_self);
 
     /* figure out second listening addr */
     hret = margo_addr_self(mid2, &addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_self()\n");
         margo_finalize(mid2);
-        return(-1);
+        return (-1);
     }
     addr_self_string_sz = 128;
-    hret = margo_addr_to_string(mid2, addr_self_string2, &addr_self_string_sz, addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    hret = margo_addr_to_string(mid2, addr_self_string2, &addr_self_string_sz,
+                                addr_self);
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_to_string()\n");
         margo_addr_free(mid2, addr_self);
         margo_finalize(mid2);
-        return(-1);
+        return (-1);
     }
     margo_addr_free(mid2, addr_self);
 
-
-    fprintf(stderr, "# accepting RPCs on address \"%s\" and \"%s\"\n", addr_self_string1, addr_self_string2);
+    fprintf(stderr, "# accepting RPCs on address \"%s\" and \"%s\"\n",
+            addr_self_string1, addr_self_string2);
 
     /* register RPC */
     MARGO_REGISTER(mid1, "my_rpc", my_rpc_in_t, my_rpc_out_t, my_rpc_ult);
@@ -106,5 +101,5 @@ int main(int argc, char **argv)
     margo_wait_for_finalize(mid1);
     margo_wait_for_finalize(mid2);
 
-    return(0);
+    return (0);
 }

--- a/examples/margo-example-server.c
+++ b/examples/margo-example-server.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -18,20 +18,19 @@
  * and then executes indefinitely.
  */
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid;
-    hg_addr_t addr_self;
-    char addr_self_string[128];
-    hg_size_t addr_self_string_sz = 128;
-    char *cfg_str;
+    hg_addr_t         addr_self;
+    char              addr_self_string[128];
+    hg_size_t         addr_self_string_sz = 128;
+    char*             cfg_str;
 
-    if(argc != 2)
-    {
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./server <listen_addr>\n");
         fprintf(stderr, "Example: ./server na+sm://\n");
-        return(-1);
+        return (-1);
     }
 
     /* actually start margo -- this step encapsulates the Mercury and
@@ -40,28 +39,26 @@ int main(int argc, char **argv)
     /***************************************/
     margo_set_global_log_level(MARGO_LOG_TRACE);
     mid = margo_init(argv[1], MARGO_SERVER_MODE, 0, -1);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
     margo_diag_start(mid);
-    
+
     /* figure out what address this server is listening on */
     hret = margo_addr_self(mid, &addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_self()\n");
         margo_finalize(mid);
-        return(-1);
+        return (-1);
     }
-    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz, addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz,
+                                addr_self);
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_to_string()\n");
         margo_addr_free(mid, addr_self);
         margo_finalize(mid);
-        return(-1);
+        return (-1);
     }
     margo_addr_free(mid, addr_self);
 
@@ -82,5 +79,5 @@ int main(int argc, char **argv)
      */
     margo_wait_for_finalize(mid);
 
-    return(0);
+    return (0);
 }

--- a/examples/multiplex/margo-example-mp-client.c
+++ b/examples/multiplex/margo-example-mp-client.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -15,29 +15,27 @@
 
 static hg_id_t my_rpc_shutdown_id;
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
     margo_instance_id mid;
-    hg_return_t hret;
-    hg_addr_t svr_addr = HG_ADDR_NULL;
-    hg_handle_t handle;
-    char *proto;
-    char *colon;
-  
-    if(argc != 2)
-    {
+    hg_return_t       hret;
+    hg_addr_t         svr_addr = HG_ADDR_NULL;
+    hg_handle_t       handle;
+    char*             proto;
+    char*             colon;
+
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./client <server_addr>\n");
-        return(-1);
+        return (-1);
     }
-       
+
     /* initialize Mercury using the transport portion of the destination
      * address (i.e., the part before the first : character if present)
      */
     proto = strdup(argv[1]);
     assert(proto);
     colon = strchr(proto, ':');
-    if(colon)
-        *colon = '\0';
+    if (colon) *colon = '\0';
 
     /* actually start margo -- margo_init() encapsulates the Mercury &
      * Argobots initialization, so this step must precede their use. */
@@ -49,14 +47,14 @@ int main(int argc, char **argv)
     /***************************************/
     mid = margo_init(proto, MARGO_CLIENT_MODE, 0, 0);
     free(proto);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
 
     /* register core RPC */
-    my_rpc_shutdown_id = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
+    my_rpc_shutdown_id
+        = MARGO_REGISTER(mid, "my_shutdown_rpc", void, void, NULL);
     /* register service APIs */
     svc1_register_client(mid);
     svc2_register_client(mid);
@@ -86,5 +84,5 @@ int main(int argc, char **argv)
     /* shut down everything */
     margo_finalize(mid);
 
-    return(0);
+    return (0);
 }

--- a/examples/multiplex/margo-example-mp-server.c
+++ b/examples/multiplex/margo-example-mp-server.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -22,10 +22,10 @@
 
 static void my_rpc_shutdown_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid;
 
-    //printf("Got RPC request to shutdown\n");
+    // printf("Got RPC request to shutdown\n");
 
     mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
@@ -45,24 +45,22 @@ static void my_rpc_shutdown_ult(hg_handle_t handle)
 }
 DEFINE_MARGO_RPC_HANDLER(my_rpc_shutdown_ult)
 
-
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
-    int ret;
+    int               ret;
     margo_instance_id mid;
-    hg_return_t hret;
-    hg_addr_t addr_self;
-    char addr_self_string[128];
-    hg_size_t addr_self_string_sz = 128;
-    ABT_xstream svc1_xstream2;
-    ABT_pool svc1_pool2;
-    ABT_pool handler_pool;
+    hg_return_t       hret;
+    hg_addr_t         addr_self;
+    char              addr_self_string[128];
+    hg_size_t         addr_self_string_sz = 128;
+    ABT_xstream       svc1_xstream2;
+    ABT_pool          svc1_pool2;
+    ABT_pool          handler_pool;
 
-    if(argc != 2)
-    {
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./server <listen_addr>\n");
         fprintf(stderr, "Example: ./server na+sm://\n");
-        return(-1);
+        return (-1);
     }
 
     /* actually start margo -- this step encapsulates the Mercury and
@@ -70,27 +68,25 @@ int main(int argc, char **argv)
     /* Use the calling xstream to drive progress and execute handlers. */
     /***************************************/
     mid = margo_init(argv[1], MARGO_SERVER_MODE, 0, -1);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
 
     /* figure out what address this server is listening on */
     hret = margo_addr_self(mid, &addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_self()\n");
         margo_finalize(mid);
-        return(-1);
+        return (-1);
     }
-    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz, addr_self);
-    if(hret != HG_SUCCESS)
-    {
+    hret = margo_addr_to_string(mid, addr_self_string, &addr_self_string_sz,
+                                addr_self);
+    if (hret != HG_SUCCESS) {
         fprintf(stderr, "Error: margo_addr_to_string()\n");
         margo_addr_free(mid, addr_self);
         margo_finalize(mid);
-        return(-1);
+        return (-1);
     }
     margo_addr_free(mid, addr_self);
 
@@ -112,10 +108,10 @@ int main(int argc, char **argv)
     assert(ret == 0);
 
     /* create a dedicated xstream and pool for another instance of svc1 */
-	ret = ABT_xstream_create(ABT_SCHED_NULL, &svc1_xstream2);
-	assert(ret == 0);
-	ret = ABT_xstream_get_main_pools(svc1_xstream2, 1, &svc1_pool2);
-	assert(ret == 0);
+    ret = ABT_xstream_create(ABT_SCHED_NULL, &svc1_xstream2);
+    assert(ret == 0);
+    ret = ABT_xstream_get_main_pools(svc1_xstream2, 1, &svc1_pool2);
+    assert(ret == 0);
 
     /* register svc1, with provider_id 2, to execute on a separate pool.  This
      * will result in svc1 being registered twice, with the client being able
@@ -141,7 +137,8 @@ int main(int argc, char **argv)
      */
     margo_wait_for_finalize(mid);
 
-    /*  TODO: rethink this; can't touch mid or use ABT after wait for finalize */
+    /*  TODO: rethink this; can't touch mid or use ABT after wait for finalize
+     */
 #if 0
     svc1_deregister(mid, *handler_pool, 1);
     svc1_deregister(mid, svc1_pool2, 2);
@@ -151,6 +148,5 @@ int main(int argc, char **argv)
     ABT_xstream_free(&svc1_xstream2);
 #endif
 
-    return(0);
+    return (0);
 }
-

--- a/examples/multiplex/svc1-client.c
+++ b/examples/multiplex/svc1-client.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -15,32 +15,35 @@
 /* NOTE: just making these global for test example, would be cleaner if there
  * were an instance pointer for the client.
  */
-static hg_id_t svc1_do_thing_id = -1;
+static hg_id_t svc1_do_thing_id       = -1;
 static hg_id_t svc1_do_other_thing_id = -1;
 
 int svc1_register_client(margo_instance_id mid)
 {
 
-    svc1_do_thing_id = MARGO_REGISTER(mid, "svc1_do_thing", 
-        svc1_do_thing_in_t, svc1_do_thing_out_t, NULL);
+    svc1_do_thing_id = MARGO_REGISTER(mid, "svc1_do_thing", svc1_do_thing_in_t,
+                                      svc1_do_thing_out_t, NULL);
 
-    svc1_do_other_thing_id = MARGO_REGISTER(mid, "svc1_do_other_thing", 
-        svc1_do_other_thing_in_t, svc1_do_other_thing_out_t, NULL);
+    svc1_do_other_thing_id
+        = MARGO_REGISTER(mid, "svc1_do_other_thing", svc1_do_other_thing_in_t,
+                         svc1_do_other_thing_out_t, NULL);
 
-    return(0);
+    return (0);
 }
 
-void svc1_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id)
+void svc1_do_thing(margo_instance_id mid,
+                   hg_addr_t         svr_addr,
+                   uint32_t          provider_id)
 {
-    hg_handle_t handle;
-    svc1_do_thing_in_t in;
+    hg_handle_t         handle;
+    svc1_do_thing_in_t  in;
     svc1_do_thing_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    hg_return_t         hret;
+    hg_size_t           size;
+    void*               buffer;
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -50,15 +53,15 @@ void svc1_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = 0;
-    hret = margo_provider_forward(provider_id, handle, &in);
+    hret         = margo_provider_forward(provider_id, handle, &in);
     assert(hret == HG_SUCCESS);
 
     /* decode response */
@@ -74,17 +77,19 @@ void svc1_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_
     return;
 }
 
-void svc1_do_other_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id)
+void svc1_do_other_thing(margo_instance_id mid,
+                         hg_addr_t         svr_addr,
+                         uint32_t          provider_id)
 {
-    hg_handle_t handle;
-    svc1_do_other_thing_in_t in;
+    hg_handle_t               handle;
+    svc1_do_other_thing_in_t  in;
     svc1_do_other_thing_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    hg_return_t               hret;
+    hg_size_t                 size;
+    void*                     buffer;
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -94,15 +99,15 @@ void svc1_do_other_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t pro
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = 0;
-    hret = margo_provider_forward(provider_id, handle, &in);
+    hret         = margo_provider_forward(provider_id, handle, &in);
     assert(hret == HG_SUCCESS);
 
     /* decode response */

--- a/examples/multiplex/svc1-client.h
+++ b/examples/multiplex/svc1-client.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -11,7 +11,11 @@
 
 int svc1_register_client(margo_instance_id mid);
 
-void svc1_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id);
-void svc1_do_other_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id);
+void svc1_do_thing(margo_instance_id mid,
+                   hg_addr_t         svr_addr,
+                   uint32_t          provider_id);
+void svc1_do_other_thing(margo_instance_id mid,
+                         hg_addr_t         svr_addr,
+                         uint32_t          provider_id);
 
 #endif /* __SVC1_CLIENT */

--- a/examples/multiplex/svc1-proto.h
+++ b/examples/multiplex/svc1-proto.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -11,12 +11,10 @@
 
 MERCURY_GEN_PROC(svc1_do_thing_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(svc1_do_thing_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 
 MERCURY_GEN_PROC(svc1_do_other_thing_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(svc1_do_other_thing_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 
 #endif /* __SVC1_PROTO */

--- a/examples/multiplex/svc1-server.c
+++ b/examples/multiplex/svc1-server.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -11,17 +11,17 @@
 
 static void svc1_do_thing_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    svc1_do_thing_out_t out;
-    svc1_do_thing_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
-    ABT_thread my_ult;
-    ABT_xstream my_xstream; 
-    pthread_t my_tid;
+    hg_return_t           hret;
+    svc1_do_thing_out_t   out;
+    svc1_do_thing_in_t    in;
+    hg_size_t             size;
+    void*                 buffer;
+    hg_bulk_t             bulk_handle;
+    const struct hg_info* hgi;
+    margo_instance_id     mid;
+    ABT_thread            my_ult;
+    ABT_xstream           my_xstream;
+    pthread_t             my_tid;
 
     hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
@@ -33,25 +33,24 @@ static void svc1_do_thing_ult(hg_handle_t handle)
     ABT_xstream_self(&my_xstream);
     ABT_thread_self(&my_ult);
     my_tid = pthread_self();
-    printf("svc1: do_thing: ult: %p, xstream %p, tid: %lu\n", 
-        my_ult, my_xstream, my_tid);
+    printf("svc1: do_thing: ult: %p, xstream %p, tid: %lu\n", my_ult,
+           my_xstream, my_tid);
 
     out.ret = 0;
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     margo_free_input(handle, &in);
@@ -69,17 +68,17 @@ DEFINE_MARGO_RPC_HANDLER(svc1_do_thing_ult)
 
 static void svc1_do_other_thing_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
+    hg_return_t               hret;
     svc1_do_other_thing_out_t out;
-    svc1_do_other_thing_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
-    ABT_thread my_ult;
-    ABT_xstream my_xstream; 
-    pthread_t my_tid;
+    svc1_do_other_thing_in_t  in;
+    hg_size_t                 size;
+    void*                     buffer;
+    hg_bulk_t                 bulk_handle;
+    const struct hg_info*     hgi;
+    margo_instance_id         mid;
+    ABT_thread                my_ult;
+    ABT_xstream               my_xstream;
+    pthread_t                 my_tid;
 
     hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
@@ -91,25 +90,24 @@ static void svc1_do_other_thing_ult(hg_handle_t handle)
     ABT_xstream_self(&my_xstream);
     ABT_thread_self(&my_ult);
     my_tid = pthread_self();
-    printf("svc1: do_other_thing: ult: %p, xstream %p, tid: %lu\n", 
-        my_ult, my_xstream, my_tid);
+    printf("svc1: do_other_thing: ult: %p, xstream %p, tid: %lu\n", my_ult,
+           my_xstream, my_tid);
 
     out.ret = 0;
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     margo_free_input(handle, &in);
@@ -127,14 +125,14 @@ DEFINE_MARGO_RPC_HANDLER(svc1_do_other_thing_ult)
 
 int svc1_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)
 {
-    MARGO_REGISTER_PROVIDER(mid, "svc1_do_thing", 
-        svc1_do_thing_in_t, svc1_do_thing_out_t, 
-        svc1_do_thing_ult, provider_id, pool);
-    MARGO_REGISTER_PROVIDER(mid, "svc1_do_other_thing", 
-        svc1_do_other_thing_in_t, svc1_do_other_thing_out_t, 
-        svc1_do_other_thing_ult, provider_id, pool);
-   
-    return(0);
+    MARGO_REGISTER_PROVIDER(mid, "svc1_do_thing", svc1_do_thing_in_t,
+                            svc1_do_thing_out_t, svc1_do_thing_ult, provider_id,
+                            pool);
+    MARGO_REGISTER_PROVIDER(mid, "svc1_do_other_thing",
+                            svc1_do_other_thing_in_t, svc1_do_other_thing_out_t,
+                            svc1_do_other_thing_ult, provider_id, pool);
+
+    return (0);
 }
 
 void svc1_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)

--- a/examples/multiplex/svc1-server.h
+++ b/examples/multiplex/svc1-server.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -9,7 +9,9 @@
 
 #include <margo.h>
 
-int svc1_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
-void svc1_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
+int  svc1_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
+void svc1_deregister(margo_instance_id mid,
+                     ABT_pool          pool,
+                     uint32_t          provider_id);
 
 #endif /* __SVC1_SERVER */

--- a/examples/multiplex/svc2-client.c
+++ b/examples/multiplex/svc2-client.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -15,31 +15,34 @@
 /* NOTE: just making these global for test example, would be cleaner if there
  * were an instance pointer for the client.
  */
-static hg_id_t svc2_do_thing_id = -1;
+static hg_id_t svc2_do_thing_id       = -1;
 static hg_id_t svc2_do_other_thing_id = -1;
 
 int svc2_register_client(margo_instance_id mid)
 {
 
-	svc2_do_thing_id = MARGO_REGISTER(mid, "svc2_do_thing",
-        svc2_do_thing_in_t, svc2_do_thing_out_t, NULL);
-	svc2_do_other_thing_id = MARGO_REGISTER(mid, "svc2_do_other_thing",
-        svc2_do_other_thing_in_t, svc2_do_other_thing_out_t, NULL);
+    svc2_do_thing_id = MARGO_REGISTER(mid, "svc2_do_thing", svc2_do_thing_in_t,
+                                      svc2_do_thing_out_t, NULL);
+    svc2_do_other_thing_id
+        = MARGO_REGISTER(mid, "svc2_do_other_thing", svc2_do_other_thing_in_t,
+                         svc2_do_other_thing_out_t, NULL);
 
-    return(0);
+    return (0);
 }
 
-void svc2_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id)
+void svc2_do_thing(margo_instance_id mid,
+                   hg_addr_t         svr_addr,
+                   uint32_t          provider_id)
 {
-    hg_handle_t handle;
-    svc2_do_thing_in_t in;
+    hg_handle_t         handle;
+    svc2_do_thing_in_t  in;
     svc2_do_thing_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    hg_return_t         hret;
+    hg_size_t           size;
+    void*               buffer;
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -49,15 +52,15 @@ void svc2_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = 0;
-    hret = margo_provider_forward(provider_id, handle, &in);
+    hret         = margo_provider_forward(provider_id, handle, &in);
     assert(hret == HG_SUCCESS);
 
     /* decode response */
@@ -73,17 +76,19 @@ void svc2_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_
     return;
 }
 
-void svc2_do_other_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id)
+void svc2_do_other_thing(margo_instance_id mid,
+                         hg_addr_t         svr_addr,
+                         uint32_t          provider_id)
 {
-    hg_handle_t handle;
-    svc2_do_other_thing_in_t in;
+    hg_handle_t               handle;
+    svc2_do_other_thing_in_t  in;
     svc2_do_other_thing_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    hg_return_t               hret;
+    hg_size_t                 size;
+    void*                     buffer;
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -93,15 +98,15 @@ void svc2_do_other_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t pro
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = 0;
-    hret = margo_provider_forward(provider_id, handle, &in);
+    hret         = margo_provider_forward(provider_id, handle, &in);
     assert(hret == HG_SUCCESS);
 
     /* decode response */

--- a/examples/multiplex/svc2-client.h
+++ b/examples/multiplex/svc2-client.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -11,7 +11,11 @@
 
 int svc2_register_client(margo_instance_id mid);
 
-void svc2_do_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id);
-void svc2_do_other_thing(margo_instance_id mid, hg_addr_t svr_addr, uint32_t provider_id);
+void svc2_do_thing(margo_instance_id mid,
+                   hg_addr_t         svr_addr,
+                   uint32_t          provider_id);
+void svc2_do_other_thing(margo_instance_id mid,
+                         hg_addr_t         svr_addr,
+                         uint32_t          provider_id);
 
 #endif /* __SVC2_CLIENT */

--- a/examples/multiplex/svc2-proto.h
+++ b/examples/multiplex/svc2-proto.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -11,12 +11,10 @@
 
 MERCURY_GEN_PROC(svc2_do_thing_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(svc2_do_thing_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 
 MERCURY_GEN_PROC(svc2_do_other_thing_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(svc2_do_other_thing_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 
 #endif /* __SVC2_PROTO */

--- a/examples/multiplex/svc2-server.c
+++ b/examples/multiplex/svc2-server.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -11,17 +11,17 @@
 
 static void svc2_do_thing_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    svc2_do_thing_out_t out;
-    svc2_do_thing_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
-    ABT_thread my_ult;
-    ABT_xstream my_xstream; 
-    pthread_t my_tid;
+    hg_return_t           hret;
+    svc2_do_thing_out_t   out;
+    svc2_do_thing_in_t    in;
+    hg_size_t             size;
+    void*                 buffer;
+    hg_bulk_t             bulk_handle;
+    const struct hg_info* hgi;
+    margo_instance_id     mid;
+    ABT_thread            my_ult;
+    ABT_xstream           my_xstream;
+    pthread_t             my_tid;
 
     hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
@@ -33,25 +33,24 @@ static void svc2_do_thing_ult(hg_handle_t handle)
     ABT_xstream_self(&my_xstream);
     ABT_thread_self(&my_ult);
     my_tid = pthread_self();
-    printf("svc2: do_thing: ult: %p, xstream %p, tid: %lu\n", 
-        my_ult, my_xstream, my_tid);
+    printf("svc2: do_thing: ult: %p, xstream %p, tid: %lu\n", my_ult,
+           my_xstream, my_tid);
 
     out.ret = 0;
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     margo_free_input(handle, &in);
@@ -69,17 +68,17 @@ DEFINE_MARGO_RPC_HANDLER(svc2_do_thing_ult)
 
 static void svc2_do_other_thing_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
+    hg_return_t               hret;
     svc2_do_other_thing_out_t out;
-    svc2_do_other_thing_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
-    ABT_thread my_ult;
-    ABT_xstream my_xstream; 
-    pthread_t my_tid;
+    svc2_do_other_thing_in_t  in;
+    hg_size_t                 size;
+    void*                     buffer;
+    hg_bulk_t                 bulk_handle;
+    const struct hg_info*     hgi;
+    margo_instance_id         mid;
+    ABT_thread                my_ult;
+    ABT_xstream               my_xstream;
+    pthread_t                 my_tid;
 
     hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
@@ -91,25 +90,24 @@ static void svc2_do_other_thing_ult(hg_handle_t handle)
     ABT_xstream_self(&my_xstream);
     ABT_thread_self(&my_ult);
     my_tid = pthread_self();
-    printf("svc2: do_other_thing: ult: %p, xstream %p, tid: %lu\n", 
-        my_ult, my_xstream, my_tid);
+    printf("svc2: do_other_thing: ult: %p, xstream %p, tid: %lu\n", my_ult,
+           my_xstream, my_tid);
 
     out.ret = 0;
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     margo_free_input(handle, &in);
@@ -127,14 +125,14 @@ DEFINE_MARGO_RPC_HANDLER(svc2_do_other_thing_ult)
 
 int svc2_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)
 {
-    MARGO_REGISTER_PROVIDER(mid, "svc2_do_thing", 
-        svc2_do_thing_in_t, svc2_do_thing_out_t, 
-        svc2_do_thing_ult, provider_id, pool);
-    MARGO_REGISTER_PROVIDER(mid, "svc2_do_other_thing", 
-        svc2_do_other_thing_in_t, svc2_do_other_thing_out_t, 
-        svc2_do_other_thing_ult, provider_id, pool);
-   
-    return(0);
+    MARGO_REGISTER_PROVIDER(mid, "svc2_do_thing", svc2_do_thing_in_t,
+                            svc2_do_thing_out_t, svc2_do_thing_ult, provider_id,
+                            pool);
+    MARGO_REGISTER_PROVIDER(mid, "svc2_do_other_thing",
+                            svc2_do_other_thing_in_t, svc2_do_other_thing_out_t,
+                            svc2_do_other_thing_ult, provider_id, pool);
+
+    return (0);
 }
 
 void svc2_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id)

--- a/examples/multiplex/svc2-server.h
+++ b/examples/multiplex/svc2-server.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -9,7 +9,9 @@
 
 #include <margo.h>
 
-int svc2_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
-void svc2_deregister(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
+int  svc2_register(margo_instance_id mid, ABT_pool pool, uint32_t provider_id);
+void svc2_deregister(margo_instance_id mid,
+                     ABT_pool          pool,
+                     uint32_t          provider_id);
 
 #endif /* __SVC2_SERVER */

--- a/examples/my-rpc.c
+++ b/examples/my-rpc.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -8,7 +8,7 @@
 #include "my-rpc.h"
 
 /* my-rpc:
- * This is an example RPC operation.  It includes a small bulk transfer, 
+ * This is an example RPC operation.  It includes a small bulk transfer,
  * driven by the server, that moves data from the client to the server.  The
  * server writes the data to a local file in /tmp.
  */
@@ -20,13 +20,13 @@
 
 static void my_rpc_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    my_rpc_out_t out;
-    my_rpc_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
+    hg_return_t           hret;
+    my_rpc_out_t          out;
+    my_rpc_in_t           in;
+    hg_size_t             size;
+    void*                 buffer;
+    hg_bulk_t             bulk_handle;
+    const struct hg_info* hgi;
 #if 0
     int ret;
     int fd;
@@ -41,7 +41,7 @@ static void my_rpc_ult(hg_handle_t handle)
     out.ret = 0;
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
@@ -52,14 +52,13 @@ static void my_rpc_ult(hg_handle_t handle)
     assert(mid != MARGO_INSTANCE_NULL);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     /* write to a file; would be done with abt-io if we enabled it */
@@ -89,7 +88,7 @@ DEFINE_MARGO_RPC_HANDLER(my_rpc_ult)
 
 static void my_rpc_shutdown_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid;
 
     printf("Got RPC request to shutdown\n");

--- a/examples/my-rpc.h
+++ b/examples/my-rpc.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -12,9 +12,7 @@
 /* visible API for example RPC operation */
 
 MERCURY_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(my_rpc_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+MERCURY_GEN_PROC(my_rpc_in_t, ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 DECLARE_MARGO_RPC_HANDLER(my_rpc_ult)
 
 DECLARE_MARGO_RPC_HANDLER(my_rpc_shutdown_ult)

--- a/tests/margo-test-client-error.c
+++ b/tests/margo-test-client-error.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -20,114 +20,103 @@
  * The HG forward call is executed using asynchronous operations.
  */
 
-struct run_my_rpc_args
-{
-    int val;
+struct run_my_rpc_args {
+    int               val;
     margo_instance_id mid;
-    hg_addr_t svr_addr;
+    hg_addr_t         svr_addr;
 };
 
-static void run_my_rpc(void *_arg);
+static void run_my_rpc(void* _arg);
 
 static hg_id_t my_rpc_hang_id;
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
     struct run_my_rpc_args args[4];
-    ABT_thread threads[4];
-    int i;
-    int ret;
-    hg_return_t hret;
-    ABT_xstream xstream;
-    ABT_pool pool;
-    margo_instance_id mid;
-    hg_addr_t svr_addr = HG_ADDR_NULL;
-    char proto[12] = {0};
-      
-    if(argc != 2)
-    {
+    ABT_thread             threads[4];
+    int                    i;
+    int                    ret;
+    hg_return_t            hret;
+    ABT_xstream            xstream;
+    ABT_pool               pool;
+    margo_instance_id      mid;
+    hg_addr_t              svr_addr  = HG_ADDR_NULL;
+    char                   proto[12] = {0};
+
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./client-timeout <server_addr>\n");
-        return(-1);
+        return (-1);
     }
-   
+
     /* initialize Mercury using the transport portion of the destination
      * address (i.e., the part before the first : character if present)
      */
-    for(i=0; i<11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
+    for (i = 0; i < 11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
         proto[i] = argv[1][i];
 
     /* actually start margo -- margo_init() encapsulates the Mercury &
      * Argobots initialization, so this step must precede their use. */
     /* Use main process to drive progress (it will relinquish control to
-     * Mercury during blocking communication calls).  The rpc handler pool 
-     * is null in this example program because this is a pure client that 
+     * Mercury during blocking communication calls).  The rpc handler pool
+     * is null in this example program because this is a pure client that
      * will not be servicing rpc requests.
      */
     /***************************************/
     mid = margo_init(proto, MARGO_CLIENT_MODE, 0, 0);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
 
     /* retrieve current pool to use for ULT creation */
     ret = ABT_xstream_self(&xstream);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_self()\n");
-        return(-1);
+        return (-1);
     }
     ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_get_main_pools()\n");
-        return(-1);
+        return (-1);
     }
 
     /* register RPCs */
-    my_rpc_hang_id = MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t, my_rpc_hang_out_t, 
-        NULL);
+    my_rpc_hang_id = MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t,
+                                    my_rpc_hang_out_t, NULL);
 
     /* find addr for server */
     hret = margo_addr_lookup(mid, argv[1], &svr_addr);
     assert(hret == HG_SUCCESS);
 
-    for(i=0; i<4; i++)
-    {
-        args[i].val = i;
-        args[i].mid = mid;
+    for (i = 0; i < 4; i++) {
+        args[i].val      = i;
+        args[i].mid      = mid;
         args[i].svr_addr = svr_addr;
 
         /* Each ult gets a pointer to an element of the array to use
          * as input for the run_my_rpc() function.
          */
         ret = ABT_thread_create(pool, run_my_rpc, &args[i],
-            ABT_THREAD_ATTR_NULL, &threads[i]);
-        if(ret != 0)
-        {
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_create()\n");
-            return(-1);
+            return (-1);
         }
-
     }
 
     /* yield to one of the threads */
     ABT_thread_yield_to(threads[0]);
 
-    for(i=0; i<4; i++)
-    {
+    for (i = 0; i < 4; i++) {
         ret = ABT_thread_join(threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
         ret = ABT_thread_free(&threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
     }
 
@@ -135,24 +124,24 @@ int main(int argc, char **argv)
 
     /* shut down everything */
     margo_finalize(mid);
-    
-    return(0);
+
+    return (0);
 }
 
-static void run_my_rpc(void *_arg)
+static void run_my_rpc(void* _arg)
 {
-    struct run_my_rpc_args *arg = _arg;
-    hg_handle_t handle;
-    my_rpc_hang_in_t in;
-    my_rpc_hang_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    struct run_my_rpc_args* arg = _arg;
+    hg_handle_t             handle;
+    my_rpc_hang_in_t        in;
+    my_rpc_hang_out_t       out;
+    hg_return_t             hret;
+    hg_size_t               size;
+    void*                   buffer;
 
     printf("ULT [%d] running.\n", arg->val);
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -162,26 +151,24 @@ static void run_my_rpc(void *_arg)
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = arg->val;
     /* call with 2 second timeout */
     hret = margo_forward_timed(handle, &in, 2000.0);
 
-    if(hret == HG_SUCCESS)
-    {
+    if (hret == HG_SUCCESS) {
         /* decode response */
         hret = margo_get_output(handle, &out);
         assert(hret == HG_SUCCESS);
         printf("Got response ret: %d\n", out.ret);
         margo_free_output(handle, &out);
-    }
-    else if(hret == HG_NODEV)
+    } else if (hret == HG_NODEV)
         printf("margo_forward returned HG_NODEV\n");
     else
         printf("margo_forward returned %d\n", hret);
@@ -193,8 +180,8 @@ static void run_my_rpc(void *_arg)
 
     printf("ULT [%d] done.\n", arg->val);
 
-    /* sleep 3s 
-     * This is waiting for the undeleted timer to expire 
+    /* sleep 3s
+     * This is waiting for the undeleted timer to expire
      * Timer is setted when above margo_forward_timed is called
      * https://github.com/mochi-hpc/mochi-margo/issues/113
      */

--- a/tests/margo-test-client-timeout.c
+++ b/tests/margo-test-client-timeout.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -20,114 +20,103 @@
  * The HG forward call is executed using asynchronous operations.
  */
 
-struct run_my_rpc_args
-{
-    int val;
+struct run_my_rpc_args {
+    int               val;
     margo_instance_id mid;
-    hg_addr_t svr_addr;
+    hg_addr_t         svr_addr;
 };
 
-static void run_my_rpc(void *_arg);
+static void run_my_rpc(void* _arg);
 
 static hg_id_t my_rpc_hang_id;
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
     struct run_my_rpc_args args[4];
-    ABT_thread threads[4];
-    int i;
-    int ret;
-    hg_return_t hret;
-    ABT_xstream xstream;
-    ABT_pool pool;
-    margo_instance_id mid;
-    hg_addr_t svr_addr = HG_ADDR_NULL;
-    char proto[12] = {0};
-      
-    if(argc != 2)
-    {
+    ABT_thread             threads[4];
+    int                    i;
+    int                    ret;
+    hg_return_t            hret;
+    ABT_xstream            xstream;
+    ABT_pool               pool;
+    margo_instance_id      mid;
+    hg_addr_t              svr_addr  = HG_ADDR_NULL;
+    char                   proto[12] = {0};
+
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./client-timeout <server_addr>\n");
-        return(-1);
+        return (-1);
     }
-   
+
     /* initialize Mercury using the transport portion of the destination
      * address (i.e., the part before the first : character if present)
      */
-    for(i=0; i<11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
+    for (i = 0; i < 11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
         proto[i] = argv[1][i];
 
     /* actually start margo -- margo_init() encapsulates the Mercury &
      * Argobots initialization, so this step must precede their use. */
     /* Use main process to drive progress (it will relinquish control to
-     * Mercury during blocking communication calls).  The rpc handler pool 
-     * is null in this example program because this is a pure client that 
+     * Mercury during blocking communication calls).  The rpc handler pool
+     * is null in this example program because this is a pure client that
      * will not be servicing rpc requests.
      */
     /***************************************/
     mid = margo_init(proto, MARGO_CLIENT_MODE, 0, 0);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
 
     /* retrieve current pool to use for ULT creation */
     ret = ABT_xstream_self(&xstream);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_self()\n");
-        return(-1);
+        return (-1);
     }
     ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_get_main_pools()\n");
-        return(-1);
+        return (-1);
     }
 
     /* register RPCs */
-    my_rpc_hang_id = MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t, my_rpc_hang_out_t, 
-        NULL);
+    my_rpc_hang_id = MARGO_REGISTER(mid, "my_rpc_hang", my_rpc_hang_in_t,
+                                    my_rpc_hang_out_t, NULL);
 
     /* find addr for server */
     hret = margo_addr_lookup(mid, argv[1], &svr_addr);
     assert(hret == HG_SUCCESS);
 
-    for(i=0; i<4; i++)
-    {
-        args[i].val = i;
-        args[i].mid = mid;
+    for (i = 0; i < 4; i++) {
+        args[i].val      = i;
+        args[i].mid      = mid;
         args[i].svr_addr = svr_addr;
 
         /* Each ult gets a pointer to an element of the array to use
          * as input for the run_my_rpc() function.
          */
         ret = ABT_thread_create(pool, run_my_rpc, &args[i],
-            ABT_THREAD_ATTR_NULL, &threads[i]);
-        if(ret != 0)
-        {
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_create()\n");
-            return(-1);
+            return (-1);
         }
-
     }
 
     /* yield to one of the threads */
     ABT_thread_yield_to(threads[0]);
 
-    for(i=0; i<4; i++)
-    {
+    for (i = 0; i < 4; i++) {
         ret = ABT_thread_join(threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
         ret = ABT_thread_free(&threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
     }
 
@@ -139,24 +128,24 @@ int main(int argc, char **argv)
 
     /* shut down everything */
     margo_finalize(mid);
-    
-    return(0);
+
+    return (0);
 }
 
-static void run_my_rpc(void *_arg)
+static void run_my_rpc(void* _arg)
 {
-    struct run_my_rpc_args *arg = _arg;
-    hg_handle_t handle;
-    my_rpc_hang_in_t in;
-    my_rpc_hang_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    struct run_my_rpc_args* arg = _arg;
+    hg_handle_t             handle;
+    my_rpc_hang_in_t        in;
+    my_rpc_hang_out_t       out;
+    hg_return_t             hret;
+    hg_size_t               size;
+    void*                   buffer;
 
     printf("ULT [%d] running.\n", arg->val);
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -166,26 +155,24 @@ static void run_my_rpc(void *_arg)
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = arg->val;
     /* call with 2 second timeout */
     hret = margo_forward_timed(handle, &in, 2000.0);
 
-    if(hret == HG_SUCCESS)
-    {
+    if (hret == HG_SUCCESS) {
         /* decode response */
         hret = margo_get_output(handle, &out);
         assert(hret == HG_SUCCESS);
         printf("Got response ret: %d\n", out.ret);
         margo_free_output(handle, &out);
-    }
-    else if(hret == HG_TIMEOUT)
+    } else if (hret == HG_TIMEOUT)
         printf("margo_forward returned HG_TIMEOUT\n");
     else
         printf("margo_forward returned %d\n", hret);

--- a/tests/margo-test-client.c
+++ b/tests/margo-test-client.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -20,40 +20,38 @@
  * The HG forward call is executed using asynchronous operations.
  */
 
-struct run_my_rpc_args
-{
-    int val;
+struct run_my_rpc_args {
+    int               val;
     margo_instance_id mid;
-    hg_addr_t svr_addr;
+    hg_addr_t         svr_addr;
 };
 
-static void run_my_rpc(void *_arg);
+static void run_my_rpc(void* _arg);
 
 static hg_id_t my_rpc_id;
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
     struct run_my_rpc_args args[4];
-    ABT_thread threads[4];
-    int i;
-    int ret;
-    hg_return_t hret;
-    ABT_xstream xstream;
-    ABT_pool pool;
-    margo_instance_id mid;
-    hg_addr_t svr_addr = HG_ADDR_NULL;
-    char proto[12] = {0};
-  
-    if(argc != 2)
-    {
+    ABT_thread             threads[4];
+    int                    i;
+    int                    ret;
+    hg_return_t            hret;
+    ABT_xstream            xstream;
+    ABT_pool               pool;
+    margo_instance_id      mid;
+    hg_addr_t              svr_addr  = HG_ADDR_NULL;
+    char                   proto[12] = {0};
+
+    if (argc != 2) {
         fprintf(stderr, "Usage: ./client <server_addr>\n");
-        return(-1);
+        return (-1);
     }
-       
+
     /* initialize Mercury using the transport portion of the destination
      * address (i.e., the part before the first : character if present)
      */
-    for(i=0; i<11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
+    for (i = 0; i < 11 && argv[1][i] != '\0' && argv[1][i] != ':'; i++)
         proto[i] = argv[1][i];
 
     /* actually start margo -- margo_init() encapsulates the Mercury &
@@ -65,24 +63,21 @@ int main(int argc, char **argv)
      */
     /***************************************/
     mid = margo_init(proto, MARGO_CLIENT_MODE, 0, 0);
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         fprintf(stderr, "Error: margo_init()\n");
-        return(-1);
+        return (-1);
     }
 
     /* retrieve current pool to use for ULT creation */
     ret = ABT_xstream_self(&xstream);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_self()\n");
-        return(-1);
+        return (-1);
     }
     ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_get_main_pools()\n");
-        return(-1);
+        return (-1);
     }
 
     /* register RPCs */
@@ -92,41 +87,35 @@ int main(int argc, char **argv)
     hret = margo_addr_lookup(mid, argv[1], &svr_addr);
     assert(hret == HG_SUCCESS);
 
-    for(i=0; i<4; i++)
-    {
-        args[i].val = i;
-        args[i].mid = mid;
+    for (i = 0; i < 4; i++) {
+        args[i].val      = i;
+        args[i].mid      = mid;
         args[i].svr_addr = svr_addr;
 
         /* Each ult gets a pointer to an element of the array to use
          * as input for the run_my_rpc() function.
          */
         ret = ABT_thread_create(pool, run_my_rpc, &args[i],
-            ABT_THREAD_ATTR_NULL, &threads[i]);
-        if(ret != 0)
-        {
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_create()\n");
-            return(-1);
+            return (-1);
         }
-
     }
 
     /* yield to one of the threads */
     ABT_thread_yield_to(threads[0]);
 
-    for(i=0; i<4; i++)
-    {
+    for (i = 0; i < 4; i++) {
         ret = ABT_thread_join(threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
         ret = ABT_thread_free(&threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
     }
 
@@ -141,23 +130,23 @@ int main(int argc, char **argv)
     /* shut down everything */
     margo_finalize(mid);
 
-    return(0);
+    return (0);
 }
 
-static void run_my_rpc(void *_arg)
+static void run_my_rpc(void* _arg)
 {
-    struct run_my_rpc_args *arg = _arg;
-    hg_handle_t handle;
-    my_rpc_in_t in;
-    my_rpc_out_t out;
-    hg_return_t hret;
-    hg_size_t size;
-    void* buffer;
+    struct run_my_rpc_args* arg = _arg;
+    hg_handle_t             handle;
+    my_rpc_in_t             in;
+    my_rpc_out_t            out;
+    hg_return_t             hret;
+    hg_size_t               size;
+    void*                   buffer;
 
     printf("ULT [%d] running.\n", arg->val);
 
     /* allocate buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
     sprintf((char*)buffer, "Hello world!\n");
@@ -167,15 +156,15 @@ static void run_my_rpc(void *_arg)
     assert(hret == HG_SUCCESS);
 
     /* register buffer for rdma/bulk access by server */
-    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, 
-        HG_BULK_READ_ONLY, &in.bulk_handle);
+    hret = margo_bulk_create(arg->mid, 1, &buffer, &size, HG_BULK_READ_ONLY,
+                             &in.bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* Send rpc. Note that we are also transmitting the bulk handle in the
-     * input struct.  It was set above. 
-     */ 
+     * input struct.  It was set above.
+     */
     in.input_val = arg->val;
-    hret = margo_forward(handle, &in);
+    hret         = margo_forward(handle, &in);
     assert(hret == HG_SUCCESS);
 
     /* decode response */

--- a/tests/margo-test-init-ext.c
+++ b/tests/margo-test-init-ext.c
@@ -11,9 +11,10 @@
 #include <margo.h>
 #include <margo-logging.h>
 
-char* readfile(const char* filename) {
-    FILE *f = fopen(filename, "r");
-    if(!f) {
+char* readfile(const char* filename)
+{
+    FILE* f = fopen(filename, "r");
+    if (!f) {
         perror("fopen");
         fprintf(stderr, "\tCould not open json file \"%s\"\n", filename);
         exit(EXIT_FAILURE);
@@ -28,13 +29,13 @@ char* readfile(const char* filename) {
     return string;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     margo_set_global_log_level(MARGO_LOG_TRACE);
 
-    margo_instance_id mid;
-    struct margo_init_info args = { 0 };
-    args.json_config = argc > 1 ? readfile(argv[1]) : NULL;
+    margo_instance_id      mid;
+    struct margo_init_info args = {0};
+    args.json_config            = argc > 1 ? readfile(argv[1]) : NULL;
 
     mid = margo_init_ext("na+sm", MARGO_CLIENT_MODE, &args);
 

--- a/tests/margo-test-sleep.c
+++ b/tests/margo-test-sleep.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2016 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -13,40 +13,40 @@
 #include <margo.h>
 #include <margo-logging.h>
 
-static int use_abt_sleep = 0;
-static int sleep_seconds = 2;
+static int               use_abt_sleep = 0;
+static int               sleep_seconds = 2;
 static margo_instance_id mid;
 
-static void sleep_fn(void *arg);
+static void sleep_fn(void* arg);
 
-int main(int argc, char **argv) 
+int main(int argc, char** argv)
 {
-    ABT_thread threads[4];
-    int t_ids[4];
-    int i;
-    int ret;
+    ABT_thread  threads[4];
+    int         t_ids[4];
+    int         i;
+    int         ret;
     ABT_xstream xstream;
-    ABT_pool pool;
+    ABT_pool    pool;
 
     int arg_ndx = 1;
-    if(argc > 1)
-    {
-        if(isdigit(argv[1][0]))
-        {
+    if (argc > 1) {
+        if (isdigit(argv[1][0])) {
             sleep_seconds = atoi(argv[1]);
             arg_ndx++;
         }
-        if((arg_ndx < argc) && (strcmp(argv[arg_ndx], "ABT") == 0))
-        {
+        if ((arg_ndx < argc) && (strcmp(argv[arg_ndx], "ABT") == 0)) {
             use_abt_sleep = 1;
             arg_ndx++;
         }
-        if(arg_ndx != argc)
-        {
+        if (arg_ndx != argc) {
             fprintf(stderr, "Usage: %s [sleep_seconds] [ABT]\n", argv[0]);
-            fprintf(stderr, "\tsleep_seconds: number of seconds for each thread to sleep.\n");
-            fprintf(stderr, "\tABT: use ABT sleep mechanism, rather than POSIX sleep.\n");
-            return(-1);
+            fprintf(stderr,
+                    "\tsleep_seconds: number of seconds for each thread to "
+                    "sleep.\n");
+            fprintf(
+                stderr,
+                "\tABT: use ABT sleep mechanism, rather than POSIX sleep.\n");
+            return (-1);
         }
     }
 
@@ -56,79 +56,69 @@ int main(int argc, char **argv)
     /* NOTE: we don't use RPC handlers, so no need for an RPC pool */
     /***************************************/
     mid = margo_init("tcp", MARGO_CLIENT_MODE, 0, 0);
-//    margo_set_log_level(mid, MARGO_LOG_TRACE);
+    //    margo_set_log_level(mid, MARGO_LOG_TRACE);
 
-    if(mid == MARGO_INSTANCE_NULL)
-    {
+    if (mid == MARGO_INSTANCE_NULL) {
         /* if tcp didn't work, try sm */
         mid = margo_init("sm", MARGO_CLIENT_MODE, 0, 0);
-        if(mid == MARGO_INSTANCE_NULL)
-        {
+        if (mid == MARGO_INSTANCE_NULL) {
             fprintf(stderr, "Error: margo_init()\n");
-            return(-1);
+            return (-1);
         }
     }
 
     /* retrieve current pool to use for ULT creation */
     ret = ABT_xstream_self(&xstream);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_self()\n");
-        return(-1);
+        return (-1);
     }
     ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    if(ret != 0)
-    {
+    if (ret != 0) {
         fprintf(stderr, "Error: ABT_xstream_get_main_pools()\n");
-        return(-1);
+        return (-1);
     }
 
-    for(i=0; i<4; i++)
-    {
+    for (i = 0; i < 4; i++) {
         t_ids[i] = i;
 
         /* start up the sleeper threads */
-        ret = ABT_thread_create(pool, sleep_fn, &t_ids[i],
-            ABT_THREAD_ATTR_NULL, &threads[i]);
-        if(ret != 0)
-        {
+        ret = ABT_thread_create(pool, sleep_fn, &t_ids[i], ABT_THREAD_ATTR_NULL,
+                                &threads[i]);
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_create()\n");
-            return(-1);
+            return (-1);
         }
-
     }
 
     /* yield to one of the threads */
     ABT_thread_yield_to(threads[0]);
 
-    for(i=0; i<4; i++)
-    {
+    for (i = 0; i < 4; i++) {
         ret = ABT_thread_join(threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
         ret = ABT_thread_free(&threads[i]);
-        if(ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "Error: ABT_thread_join()\n");
-            return(-1);
+            return (-1);
         }
     }
 
     /* shut down everything */
     margo_finalize(mid);
-    
-    return(0);
+
+    return (0);
 }
 
-static void sleep_fn(void *arg)
+static void sleep_fn(void* arg)
 {
-    int my_tid = *(int *)arg;
+    int my_tid = *(int*)arg;
 
-    if(use_abt_sleep)
-        margo_thread_sleep(mid, sleep_seconds*1000.0);
+    if (use_abt_sleep)
+        margo_thread_sleep(mid, sleep_seconds * 1000.0);
     else
         sleep(sleep_seconds);
 

--- a/tests/my-rpc.c
+++ b/tests/my-rpc.c
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -8,7 +8,7 @@
 #include "my-rpc.h"
 
 /* my-rpc:
- * This is an example RPC operation.  It includes a small bulk transfer, 
+ * This is an example RPC operation.  It includes a small bulk transfer,
  * driven by the server, that moves data from the client to the server.  The
  * server writes the data to a local file in /tmp.
  */
@@ -20,13 +20,13 @@
 
 static void my_rpc_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    my_rpc_out_t out;
-    my_rpc_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
+    hg_return_t           hret;
+    my_rpc_out_t          out;
+    my_rpc_in_t           in;
+    hg_size_t             size;
+    void*                 buffer;
+    hg_bulk_t             bulk_handle;
+    const struct hg_info* hgi;
 #if 0
     int ret;
     int fd;
@@ -41,7 +41,7 @@ static void my_rpc_ult(hg_handle_t handle)
     out.ret = 0;
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
@@ -52,14 +52,13 @@ static void my_rpc_ult(hg_handle_t handle)
     assert(mid != MARGO_INSTANCE_NULL);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     /* write to a file; would be done with abt-io if we enabled it */
@@ -89,7 +88,7 @@ DEFINE_MARGO_RPC_HANDLER(my_rpc_ult)
 
 static void my_rpc_shutdown_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
+    hg_return_t       hret;
     margo_instance_id mid;
 
     printf("Got RPC request to shutdown\n");
@@ -115,19 +114,20 @@ DEFINE_MARGO_RPC_HANDLER(my_rpc_shutdown_ult)
 
 static void my_rpc_hang_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-    my_rpc_out_t out;
-    my_rpc_in_t in;
-    hg_size_t size;
-    void *buffer;
-    hg_bulk_t bulk_handle;
-    const struct hg_info *hgi;
-    margo_instance_id mid;
+    hg_return_t           hret;
+    my_rpc_out_t          out;
+    my_rpc_in_t           in;
+    hg_size_t             size;
+    void*                 buffer;
+    hg_bulk_t             bulk_handle;
+    const struct hg_info* hgi;
+    margo_instance_id     mid;
 
     hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
 
-    printf("Got RPC request with input_val: %d, deliberately hanging.\n", in.input_val);
+    printf("Got RPC request with input_val: %d, deliberately hanging.\n",
+           in.input_val);
     out.ret = 0;
 
     /* get handle info and margo instance */
@@ -137,22 +137,21 @@ static void my_rpc_hang_ult(hg_handle_t handle)
     assert(mid != MARGO_INSTANCE_NULL);
 
     /* sleep for an hour (to allow client to test timeout capability) */
-    margo_thread_sleep(mid, 1000*60*60);
+    margo_thread_sleep(mid, 1000 * 60 * 60);
 
     /* set up target buffer for bulk transfer */
-    size = 512;
+    size   = 512;
     buffer = calloc(1, 512);
     assert(buffer);
 
     /* register local target buffer for bulk access */
-    hret = margo_bulk_create(mid, 1, &buffer,
-        &size, HG_BULK_WRITE_ONLY, &bulk_handle);
+    hret = margo_bulk_create(mid, 1, &buffer, &size, HG_BULK_WRITE_ONLY,
+                             &bulk_handle);
     assert(hret == HG_SUCCESS);
 
     /* do bulk transfer from client to server */
-    hret = margo_bulk_transfer(mid, HG_BULK_PULL,
-        hgi->addr, in.bulk_handle, 0,
-        bulk_handle, 0, size);
+    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr, in.bulk_handle, 0,
+                               bulk_handle, 0, size);
     assert(hret == HG_SUCCESS);
 
     margo_free_input(handle, &in);

--- a/tests/my-rpc.h
+++ b/tests/my-rpc.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2015 The University of Chicago
- * 
+ *
  * See COPYRIGHT in top-level directory.
  */
 
@@ -13,14 +13,11 @@
 
 MERCURY_GEN_PROC(my_rpc_hang_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(my_rpc_hang_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+                 ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 DECLARE_MARGO_RPC_HANDLER(my_rpc_hang_ult)
 
 MERCURY_GEN_PROC(my_rpc_out_t, ((int32_t)(ret)))
-MERCURY_GEN_PROC(my_rpc_in_t,
-    ((int32_t)(input_val))\
-    ((hg_bulk_t)(bulk_handle)))
+MERCURY_GEN_PROC(my_rpc_in_t, ((int32_t)(input_val))((hg_bulk_t)(bulk_handle)))
 DECLARE_MARGO_RPC_HANDLER(my_rpc_ult)
 
 DECLARE_MARGO_RPC_HANDLER(my_rpc_shutdown_ult)


### PR DESCRIPTION
Applies clang format to remaining code in the tree (including examples and test programs)