### PR TITLE
configurable out dir for profiling and diag

### DIFF
--- a/doc/instrumentation.md
+++ b/doc/instrumentation.md
@@ -10,6 +10,11 @@ loop.  The second (breadcrumb profiling) measures time spent invoking remote pro
 
 ## Usage
 
+Note that all instrumentation output files described below will be emitted
+in the current working directory of the program by default.  You can specify
+an alternative directory with the `MARGO_OUTPUT_DIR` environment variable or
+the `output_dir` json parameter.
+
 Diagnostics can be enabled in two ways:
 * At program startup, setting the env variable `MARGO_ENABLE_DIAGNOSTICS` to `1`.
 * At run time by calling the `margo_diag_start()` any

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -278,13 +278,34 @@ void margo_finalize(margo_instance_id mid)
                     "Waiting for sparkline data collection thread to complete");
         ABT_thread_join(mid->sparkline_data_collection_tid);
         ABT_thread_free(&mid->sparkline_data_collection_tid);
-        MARGO_TRACE(mid, "Dumping profile");
-        margo_profile_dump(mid, "profile", 1);
+
+        char* profile_out_filename
+            = malloc(strlen(json_object_get_string(
+                         json_object_object_get(mid->json_cfg, "output_dir")))
+                     + 12);
+        if (profile_out_filename) {
+            sprintf(profile_out_filename, "%s/profile",
+                    json_object_get_string(
+                        json_object_object_get(mid->json_cfg, "output_dir")));
+            MARGO_TRACE(mid, "Dumping profile");
+            margo_profile_dump(mid, profile_out_filename, 1);
+            free(profile_out_filename);
+        }
     }
 
     if (mid->diag_enabled) {
-        MARGO_TRACE(mid, "Dumping diagnostics");
-        margo_diag_dump(mid, "profile", 1);
+        char* profile_out_filename
+            = malloc(strlen(json_object_get_string(
+                         json_object_object_get(mid->json_cfg, "output_dir")))
+                     + 12);
+        if (profile_out_filename) {
+            sprintf(profile_out_filename, "%s/profile",
+                    json_object_get_string(
+                        json_object_object_get(mid->json_cfg, "output_dir")));
+            MARGO_TRACE(mid, "Dumping diagnostics");
+            margo_diag_dump(mid, profile_out_filename, 1);
+            free(profile_out_filename);
+        }
     }
 
     ABT_mutex_lock(mid->finalize_mutex);

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -475,6 +475,22 @@ validate_and_complete_config(struct json_object*        _margo,
                     json_object_get_boolean(val) ? "true" : "false");
     }
 
+    { // add or override output_dir
+        char* margo_output_dir_str = getenv("MARGO_OUTPUT_DIR");
+        if (margo_output_dir_str) {
+            CONFIG_HAS_OR_CREATE(_margo, string, "output_dir",
+                                 margo_output_dir_str, "output_dir", val);
+        } else {
+            margo_output_dir_str = getcwd(NULL, 0);
+            CONFIG_HAS_OR_CREATE(_margo, string, "output_dir",
+                                 margo_output_dir_str, "output_dir", val);
+            /* getwd() mallocs the string if buf is NULL */
+            free(margo_output_dir_str);
+        }
+
+        MARGO_TRACE(0, "output_dir = %s", json_object_get_string(val));
+    }
+
     { // add or override handle_cache_size
         CONFIG_HAS_OR_CREATE(_margo, int64, "handle_cache_size", 32,
                              "handle_cache_size", val);


### PR DESCRIPTION
This adds a json parameter (`output_dir`) and environment variable (`MARGO_OUTPUT_DIR`) that can be used to specify the default directory that profiling and diagnostics files will be emitted to if they are enabled at runtime.

If neither the json nor env dir are specified, then margo will still use the current working directory as before.

Fixes #57 