### PR TITLE
refactor output file handline for diag/prof

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -1176,7 +1176,10 @@ margo_instance_id margo_hg_info_get_instance(const struct hg_info* info);
  * output file.
  *
  * @param [in] mid Margo instance
- * @param [in] file output file ("-" for stdout)
+ * @param [in] file output file ("-" for stdout).  If string begins with '/'
+ *   character then it will be treated as an absolute path.  Otherwise the
+ *   file will be placed in the directory specified output_dir or
+ *   MARGO_OUTPUT_DIR.
  * @param [in] uniquify flag indicating if file name should have additional
  *   information added to it to make output from different processes unique
  * @returns void
@@ -1188,7 +1191,10 @@ void margo_diag_dump(margo_instance_id mid, const char* file, int uniquify);
  * output file.
  *
  * @param [in] mid Margo instance
- * @param [in] file output file ("-" for stdout)
+ * @param [in] file output file ("-" for stdout).  If string begins with '/'
+ *   character then it will be treated as an absolute path.  Otherwise the
+ *   file will be placed in the directory specified output_dir or
+ *   MARGO_OUTPUT_DIR.
  * @param [in] uniquify flag indicating if file name should have additional
  *   information added to it to make output from different processes unique
  * @returns void

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -279,33 +279,13 @@ void margo_finalize(margo_instance_id mid)
         ABT_thread_join(mid->sparkline_data_collection_tid);
         ABT_thread_free(&mid->sparkline_data_collection_tid);
 
-        char* profile_out_filename
-            = malloc(strlen(json_object_get_string(
-                         json_object_object_get(mid->json_cfg, "output_dir")))
-                     + 12);
-        if (profile_out_filename) {
-            sprintf(profile_out_filename, "%s/profile",
-                    json_object_get_string(
-                        json_object_object_get(mid->json_cfg, "output_dir")));
-            MARGO_TRACE(mid, "Dumping profile");
-            margo_profile_dump(mid, profile_out_filename, 1);
-            free(profile_out_filename);
-        }
+        MARGO_TRACE(mid, "Dumping profile");
+        margo_profile_dump(mid, "profile", 1);
     }
 
     if (mid->diag_enabled) {
-        char* profile_out_filename
-            = malloc(strlen(json_object_get_string(
-                         json_object_object_get(mid->json_cfg, "output_dir")))
-                     + 12);
-        if (profile_out_filename) {
-            sprintf(profile_out_filename, "%s/profile",
-                    json_object_get_string(
-                        json_object_object_get(mid->json_cfg, "output_dir")));
-            MARGO_TRACE(mid, "Dumping diagnostics");
-            margo_diag_dump(mid, profile_out_filename, 1);
-            free(profile_out_filename);
-        }
+        MARGO_TRACE(mid, "Dumping diagnostics");
+        margo_diag_dump(mid, "profile", 1);
     }
 
     ABT_mutex_lock(mid->finalize_mutex);


### PR DESCRIPTION
- unify path parsing into one subroutine
- use margo logging rather than perror
- Inject output_dir path within API rather than expecting caller to do
  so.  This can be overriden by passing an absolute path parameter.