### PR TITLE
unit test and bug fix for init/finalize cycles

### DIFF
--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -1,11 +1,13 @@
 if BUILD_TESTS
 check_PROGRAMS += \
  tests/unit-tests/margo-addr \
- tests/unit-tests/margo-diag
+ tests/unit-tests/margo-diag \
+ tests/unit-tests/margo-init
 
 TESTS += \
  tests/unit-tests/margo-addr \
- tests/unit-tests/margo-diag
+ tests/unit-tests/margo-diag \
+ tests/unit-tests/margo-init
 
 tests_unit_tests_margo_addr_SOURCES = \
  tests/unit-tests/munit/munit.c \
@@ -15,6 +17,11 @@ tests_unit_tests_margo_addr_SOURCES = \
 tests_unit_tests_margo_diag_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-diag.c \
+ tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_init_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-init.c \
  tests/unit-tests/helper-server.c
 
 endif

--- a/tests/unit-tests/margo-init.c
+++ b/tests/unit-tests/margo-init.c
@@ -1,0 +1,78 @@
+
+#include <margo.h>
+#include "helper-server.h"
+#include "munit/munit.h"
+
+struct test_context {
+    margo_instance_id mid;
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void) params;
+    (void) user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+
+    return ctx;
+}
+
+static void test_context_tear_down(void *data)
+{
+    struct test_context *ctx = (struct test_context*)data;
+
+    free(ctx);
+}
+
+/* test repeated init/finalize cycles, server mode */
+static MunitResult init_cycle_server(const MunitParameter params[], void* data)
+{
+    char * protocol = "na+sm";
+    struct test_context* ctx = (struct test_context*)data;
+
+    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    margo_finalize(ctx->mid);
+
+    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    margo_finalize(ctx->mid);
+
+    return MUNIT_OK;
+}
+
+/* test repeated init/finalize cycles, client mode */
+static MunitResult init_cycle_client(const MunitParameter params[], void* data)
+{
+    char * protocol = "na+sm";
+    struct test_context* ctx = (struct test_context*)data;
+
+    ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    margo_finalize(ctx->mid);
+
+    ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    margo_finalize(ctx->mid);
+
+    return MUNIT_OK;
+}
+
+static MunitTest tests[] = {
+    { "/init-cycle-client", init_cycle_client, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { "/init-cycle-server", init_cycle_server, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};
+
+static const MunitSuite test_suite = {
+    "/margo", tests, NULL, 1, MUNIT_SUITE_OPTION_NONE
+};
+
+
+int main(int argc, char **argv)
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}


### PR DESCRIPTION
Fixes #134 and #133 

This PR adds a unit test for finalizing and re-initializing margo in the same execution.

Also fixes two bugs:
- crash on re-initialization with profiling enabled
- old memory leak for abt thread-local keys used for rpc profiling