### PR TITLE
fix misc memory leaks in diagnostics and diagnostics testing path

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -1256,6 +1256,16 @@ void margo_breadcrumb_snapshot(margo_instance_id                 mid,
                                struct margo_breadcrumb_snapshot* snap);
 
 /**
+ * Releases resources associated with a breadcrumb snapshot
+ *
+ * @param [in] mid Margo instance
+ * @param [in] snap Margo diagnostics snapshot
+ * @returns void
+ */
+void margo_breadcrumb_snapshot_destroy(margo_instance_id                 mid,
+                                       struct margo_breadcrumb_snapshot* snap);
+
+/**
  * Sets configurable parameters/hints
  *
  * @param [in] mid Margo instance

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -571,7 +571,7 @@ hg_id_t margo_provider_register_name(margo_instance_id mid,
             mid->registered_rpcs = tmp_rpc->next;
             free(tmp_rpc);
         }
-        return (0);
+        return (id);
     }
 
     return (id);

--- a/src/margo-diag.c
+++ b/src/margo-diag.c
@@ -282,6 +282,18 @@ uint64_t __margo_breadcrumb_set(hg_id_t rpc_id)
     return *val;
 }
 
+void margo_breadcrumb_snapshot_destroy(margo_instance_id                 mid,
+                                       struct margo_breadcrumb_snapshot* snap)
+{
+    struct margo_breadcrumb* tmp_bc      = snap->ptr;
+    struct margo_breadcrumb* tmp_bc_next = NULL;
+    while (tmp_bc) {
+        tmp_bc_next = tmp_bc->next;
+        free(tmp_bc);
+        tmp_bc = tmp_bc_next;
+    }
+}
+
 /* copy out the entire list of breadcrumbs on this margo instance */
 void margo_breadcrumb_snapshot(margo_instance_id                 mid,
                                struct margo_breadcrumb_snapshot* snap)

--- a/tests/unit-tests/margo-diag.c
+++ b/tests/unit-tests/margo-diag.c
@@ -43,6 +43,7 @@ DEFINE_MARGO_RPC_HANDLER(sum)
 static int simple_sum(margo_instance_id mid, void * data)
 {
     hg_id_t rpc_id = MARGO_REGISTER(mid, "sum", sum_in_t, sum_out_t, sum);
+    munit_assert_int(rpc_id, !=, 0);
     margo_wait_for_finalize(mid);
     return 0;
 }
@@ -180,6 +181,7 @@ static MunitResult profile_dump(const MunitParameter params[], void *data)
         margo_destroy(h);
         margo_thread_sleep(ctx->mid, 1*1000);
     }
+    margo_addr_free(ctx->mid, ctx->remote_address);
 
     margo_state_dump(ctx->mid, "-", 0, NULL);
 

--- a/tests/unit-tests/margo-diag.c
+++ b/tests/unit-tests/margo-diag.c
@@ -150,6 +150,7 @@ static MunitResult breadcrumb_snapshot(const MunitParameter params[], void *data
     struct test_context *ctx = (struct test_context *)data;
     struct margo_breadcrumb_snapshot snap;
     margo_breadcrumb_snapshot(ctx->mid,  &snap);
+    margo_breadcrumb_snapshot_destroy(ctx->mid,  &snap);
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
* includes a new helper function to safely release resources allocated by `breadcrumb_snapshot()` function