### PR TITLE
make more robust to dynamic profiling

### DIFF
--- a/src/margo-diag-internal.h
+++ b/src/margo-diag-internal.h
@@ -16,7 +16,8 @@
 #include "margo-instance.h"
 #include "margo-globals.h"
 
-void __margo_sparkline_data_collection_fn(void* foo);
+void __margo_sparkline_thread_start(margo_instance_id mid);
+void __margo_sparkline_thread_stop(margo_instance_id mid);
 
 void __margo_print_diag_data(margo_instance_id mid,
                              FILE*             file,

--- a/tests/unit-tests/margo-diag.c
+++ b/tests/unit-tests/margo-diag.c
@@ -211,7 +211,5 @@ static const MunitSuite test_suite = {
 
 int main(int argc, char **argv)
 {
-    setenv("MARGO_ENABLE_PROFILING", "1", 1);
-    setenv("MARGO_ENABLE_DIAGNOSTICS", "1", 1);
     return munit_suite_main(&test_suite, NULL, argc, argv);
 }


### PR DESCRIPTION
Fixes #137 

This PR also switches the margo_diag unit test from using environment variables to using runtime api calls to enable profiling.