### PR TITLE
fix bugs in pool kind specification for rpc pool

### DIFF
--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -934,6 +934,12 @@ validate_and_complete_config(struct json_object*        _margo,
                               "Ignoring \"use_progress_thread\" because custom "
                               "progress pool was provided\n");
             }
+            if (CONFIG_HAS(_pools, "__progress__", ignore)) {
+                MARGO_WARNING(
+                    0,
+                    "__progress__ pool defined by will NOT be used "
+                    "for progress since custom progress pool was provided");
+            }
 
         } else { // no custom pool provided as argument
 
@@ -1017,6 +1023,13 @@ validate_and_complete_config(struct json_object*        _margo,
                     struct json_object* _primary_xstream       = NULL;
                     struct json_object* _primary_sched         = NULL;
                     int                 _primary_xstream_index = -1;
+                    if (CONFIG_HAS(_pools, "__progress__", ignore))
+                        MARGO_WARNING(
+                            0,
+                            "__progress__ pool defined but will NOT be"
+                            " used for progress unless it is the first pool of "
+                            "the"
+                            " __primary__ ES");
                     // find __primary__ xstream
                     CONFIG_FIND_BY_NAME(_xstreams, "__primary__",
                                         _primary_xstream_index,
@@ -1050,8 +1063,13 @@ validate_and_complete_config(struct json_object*        _margo,
             CONFIG_OVERRIDE_INTEGER(_margo, "rpc_pool", -1, "rpc_pool", 1);
             if (CONFIG_HAS(_margo, "rpc_thread_count", ignore)) {
                 MARGO_WARNING(0,
-                              "Ignoring \"rpc_thread_count\" because custom "
+                              "\"rpc_thread_count\" ignored because custom "
                               "RPC pool was provided");
+            }
+            if (CONFIG_HAS(_pools, "__rpc__", ignore)) {
+                MARGO_WARNING(0,
+                              "__rpc__ pool defined by will NOT be used "
+                              "for RPCs since custom RPC pool was provided");
             }
 
         } else { // no custom pool provided as argument
@@ -1062,7 +1080,7 @@ validate_and_complete_config(struct json_object*        _margo,
                                ignore)) { // rpc_pool and rpc_thread_count both
                                           // specified
                     MARGO_WARNING(0,
-                                  "Ignoring \"rpc_thread_count\" ignored "
+                                  "\"rpc_thread_count\" ignored"
                                   "because \"rpc_pool\" is specified");
                 }
                 int rpc_pool_index = -1;
@@ -1106,6 +1124,11 @@ validate_and_complete_config(struct json_object*        _margo,
                         json_object_object_get(_margo, "rpc_thread_count"));
                 }
                 if (rpc_thread_count < 0) { // use progress loop's pool
+                    if (CONFIG_HAS(_pools, "__rpc__", ignore))
+                        MARGO_WARNING(0,
+                                      "__rpc__ pool defined but will NOT be the"
+                                      " pool used for RPC unless it is also "
+                                      "used as progress pool");
                     struct json_object* _progress_pool
                         = json_object_object_get(_margo, "progress_pool");
                     struct json_object* _rpc_pool
@@ -1114,6 +1137,12 @@ validate_and_complete_config(struct json_object*        _margo,
                     MARGO_TRACE(0, "rpc_pool = %d",
                                 json_object_get_int64(_rpc_pool));
                 } else if (rpc_thread_count == 0) { // use primary pool
+                    if (CONFIG_HAS(_pools, "__rpc__", ignore))
+                        MARGO_WARNING(
+                            0,
+                            "__rpc__ pool defined but will NOT be"
+                            " used for RPCs unless it is the first pool of the"
+                            " __primary__ ES");
                     // use primary xstream's scheduler's first pool for the RPC
                     // loop
                     struct json_object* _primary_xstream       = NULL;

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -3,13 +3,15 @@ check_PROGRAMS += \
  tests/unit-tests/margo-addr \
  tests/unit-tests/margo-diag \
  tests/unit-tests/margo-init \
- tests/unit-tests/margo-pool
+ tests/unit-tests/margo-pool \
+ tests/unit-tests/margo-abt-pool
 
 TESTS += \
  tests/unit-tests/margo-addr \
  tests/unit-tests/margo-diag \
  tests/unit-tests/margo-init \
- tests/unit-tests/margo-pool
+ tests/unit-tests/margo-pool \
+ tests/unit-tests/margo-abt-pool
 
 tests_unit_tests_margo_addr_SOURCES = \
  tests/unit-tests/munit/munit.c \
@@ -31,5 +33,9 @@ tests_unit_tests_margo_pool_SOURCES = \
  tests/unit-tests/margo-pool.c \
  tests/unit-tests/helper-server.c
 
+tests_unit_tests_margo_abt_pool_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-abt-pool.c \
+ tests/unit-tests/helper-server.c
 
 endif

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -1,0 +1,105 @@
+
+#include <string.h>
+#include <margo.h>
+#include "helper-server.h"
+#include "munit/munit.h"
+
+/* the intent of these unit tests is to verify the ability to modify various
+ * argobots pool settings
+ */
+
+struct test_context {
+    margo_instance_id mid;
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void) params;
+    (void) user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+
+    return ctx;
+}
+
+static void test_context_tear_down(void *data)
+{
+    struct test_context *ctx = (struct test_context*)data;
+
+    free(ctx);
+}
+
+/* count how many times the needle string appears within the haystack string */
+static int count_occurrence(const char* haystack, const char *needle)
+{
+    const char *location = haystack;
+    int count = 0;
+
+    while(location) {
+        location = strstr(location, needle);
+        if(location)
+        {
+            count++;
+            location++;
+        }
+    }
+
+    return(count);
+}
+
+/* test different ways of specifying different "kind" for
+ * dedicated rpc handler pool
+ */
+static MunitResult rpc_pool_kind(const MunitParameter params[], void* data)
+{
+    const char * protocol = "na+sm";
+    struct margo_init_info mii = {0};
+    struct test_context* ctx = (struct test_context*)data;
+    char *runtime_config;
+    int count;
+
+    mii.json_config = munit_parameters_get(params, "json");
+
+    ctx->mid = margo_init_ext(protocol, MARGO_SERVER_MODE, &mii);
+    munit_assert_not_null(ctx->mid);
+
+    /* check resulting configuration */
+    runtime_config = margo_get_config(ctx->mid);
+
+    /* just one pool with the __rpc__ name */
+    count = count_occurrence(runtime_config, "__rpc__");
+    munit_assert_int(count, ==, 1);
+
+    /* just one pool with the prio_wait kind */
+    count = count_occurrence(runtime_config, "prio_wait");
+    munit_assert_int(count, ==, 1);
+
+    free(runtime_config);
+
+    margo_finalize(ctx->mid);
+
+    return MUNIT_OK;
+}
+
+static char * json_params[] = {
+    "{ \"rpc_thread_count\":2, \"argobots\":{ \"pools\":[ { \"name\":\"__rpc__\", \"kind\":\"prio_wait\" } ] } }", NULL
+};
+
+static MunitParameterEnum rpc_pool_kind_params[] = {
+    { "json", json_params},
+    {NULL, NULL}
+};
+
+static MunitTest tests[] = {
+    { "/rpc-pool-kind", rpc_pool_kind, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, rpc_pool_kind_params},
+    { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};
+
+static const MunitSuite test_suite = {
+    "/margo", tests, NULL, 1, MUNIT_SUITE_OPTION_NONE
+};
+
+
+int main(int argc, char **argv)
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}


### PR DESCRIPTION
Right now this PR just includes an initial test case (which doesn't pass).  See #142 

Need to do the following:
- [ ] make sure that margo will not create a duplicate __rpc__ pool
- [ ] similarly make sure that margo only creates necessary xstreams within pool
- [ ] fix memory leaks if present in `get_config()`

@roblatham00 