### PR TITLE
enable warnings in global log

### DIFF
--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -1381,7 +1381,9 @@ static int create_xstream_from_config(struct json_object*          es_config,
     // get/set cpubind
     if (es_cpubind == -1) {
         ret = ABT_xstream_get_cpubind(*es, &es_cpubind);
-        if (ret != ABT_SUCCESS) {
+        if (ret == ABT_ERR_FEATURE_NA) {
+            /* feature not supported in this Argobots build; skip */
+        } else if (ret != ABT_SUCCESS) {
             MARGO_WARNING(
                 0, "ABT_xstream_get_cpubind failed to get cpubind (ret = %d)",
                 ret);
@@ -1403,7 +1405,9 @@ static int create_xstream_from_config(struct json_object*          es_config,
         // get affinity
         int num_cpus;
         ret = ABT_xstream_get_affinity(*es, 0, NULL, &num_cpus);
-        if (ret != ABT_SUCCESS) {
+        if (ret == ABT_ERR_FEATURE_NA) {
+            /* feature not supported in this Argobots build; skip */
+        } else if (ret != ABT_SUCCESS) {
             MARGO_WARNING(
                 0, "ABT_xstream_get_affinity failed to get affinity (ret = %d)",
                 ret);

--- a/src/margo-logging.c
+++ b/src/margo-logging.c
@@ -7,7 +7,7 @@
 #include "margo-instance.h"
 #include <margo-logging.h>
 
-static margo_log_level global_log_level = MARGO_LOG_ERROR;
+static margo_log_level global_log_level = MARGO_LOG_WARNING;
 
 static void _margo_log_trace(void* uargs, const char* str)
 {


### PR DESCRIPTION
The purpose is to make sure that we display any non-catastrophic warnings that occur during margo initialization.

The PR includes some test cases as well as some changes to error handling when querying abt features to avoid spurious warning messages.

This is a preliminary step towards addressing #118 .