### PR TITLE
improve handling of external Argobots initialization

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -205,6 +205,22 @@ margo_instance_id margo_init_ext(const char*                   address,
                                  const struct margo_init_info* args);
 
 /**
+ * Configures the runtime environment dependencies for use by Margo without
+ * initializing Margo.  The primary purpose of this function is to set
+ * preferred environment variables for Argobots (e.g., ULT stack size) if
+ * Argobots will be initialized before calling margo_init() or
+ * margo_init_ext().
+ *
+ * @param [in] optional_json_config The json-formatted configuration
+ *                                  parameters to be used by Margo when it
+ *                                  is initialized later (if known).  If not
+ *                                  specified, then margo_set_environment()
+ *                                  will use default values.
+ * @returns returns 0 on success, negative value on failure
+ */
+int margo_set_environment(const char* optional_json_config);
+
+/**
  * Initializes margo library with custom Mercury options.
  * @param [in] addr_str            Mercury host address with port number
  * @param [in] mode                Mode to run Margo in:

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -1492,21 +1492,19 @@ static void confirm_argobots_configuration(struct json_object* config)
     ABT_info_query_config(ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE,
                           &runtime_abt_thread_stacksize);
     if (runtime_abt_thread_stacksize != abt_thread_stacksize) {
-        MARGO_WARNING(0,
-                      "Margo requested an Argobots ULT stack size of %d, but "
-                      "Argobots is using a ULT stack size of %zd.",
-                      abt_thread_stacksize, runtime_abt_thread_stacksize);
         MARGO_WARNING(
             0,
+            "Margo requested an Argobots ULT stack size of %d, but "
+            "Argobots is using a ULT stack size of %zd. "
             "If you initialized Argobots externally before calling "
             "margo_init(), please consider calling the margo_set_environment() "
-            "before ABT_init() in order to set preferred Argobots parameters "
-            "for Margo usage.");
-        MARGO_WARNING(0,
-                      "Margo is likely to encounter stack overflows and memory "
-                      "corruption if the Argobots stack size is not large "
-                      "enough to accomodate typical userspace network "
-                      "transport libraries.");
+            "function before ABT_init() in order to set preferred Argobots "
+            "parameters for Margo usage. "
+            "Margo is likely to encounter stack overflows and memory "
+            "corruption if the Argobots stack size is not large "
+            "enough to accomodate typical userspace network "
+            "transport libraries.",
+            abt_thread_stacksize, runtime_abt_thread_stacksize);
     }
     return;
 }

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -77,8 +77,8 @@ int margo_set_environment(const char* optional_json_config)
             json_tokener_free(tokener);
             return -1;
         }
-        json_tokener_free(tokener);
     }
+    json_tokener_free(tokener);
 
     set_argobots_environment_variables(config);
 

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -54,6 +54,8 @@ static int create_xstream_from_config(struct json_object*          es_config,
 
 // Sets environment variables for Argobots
 static void set_argobots_environment_variables(struct json_object* config);
+/* confirm if Argobots is running with desired configuration or not */
+static void confirm_argobots_configuration(struct json_object* config);
 
 // Shutdown logic for a margo instance
 static void remote_shutdown_ult(hg_handle_t handle);
@@ -208,11 +210,12 @@ margo_instance_id margo_init_ext(const char*                   address,
         g_margo_abt_init = 1;
         ret              = ABT_mutex_create(&g_margo_num_instances_mtx);
         if (ret != 0) goto error;
-    } else {
-        MARGO_WARNING(0,
-                      "Argobots was initialized externally, so margo_init_ext "
-                      "could not set Argobots environment variables");
     }
+
+    /* Check if Argobots is now initialized with the desired parameters
+     * (regardless of whether Margo initialized it or not)
+     */
+    confirm_argobots_configuration(config);
 
     /* Turn on profiling capability if a) it has not been done already (this
      * is global to Argobots) and b) the argobots tool interface is enabled.
@@ -1467,6 +1470,45 @@ static int create_xstream_from_config(struct json_object*          es_config,
     }
 
     return ABT_SUCCESS;
+}
+
+static void confirm_argobots_configuration(struct json_object* config)
+{
+    /* this function assumes that the json is already fully populated */
+    size_t runtime_abt_thread_stacksize = 0;
+
+    /* retrieve expected values according to Margo configuration */
+    struct json_object* argobots = json_object_object_get(config, "argobots");
+    int                 abt_thread_stacksize = json_object_get_int64(
+        json_object_object_get(argobots, "abt_thread_stacksize"));
+
+    /* NOTE: we skip checking num_stacks; this cannot be retrieved with
+     * ABT_info_query_config(). Fortunately it also is not as crucial as the
+     * stack size.  Recent ABT releases have conservative caps on stack
+     * cache sizes by default.
+     */
+
+    /* query Argobots to see if it is in agreement */
+    ABT_info_query_config(ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE,
+                          &runtime_abt_thread_stacksize);
+    if (runtime_abt_thread_stacksize != abt_thread_stacksize) {
+        MARGO_WARNING(0,
+                      "Margo requested an Argobots ULT stack size of %d, but "
+                      "Argobots is using a ULT stack size of %zd.",
+                      abt_thread_stacksize, runtime_abt_thread_stacksize);
+        MARGO_WARNING(
+            0,
+            "If you initialized Argobots externally before calling "
+            "margo_init(), please consider calling the margo_set_environment() "
+            "before ABT_init() in order to set preferred Argobots parameters "
+            "for Margo usage.");
+        MARGO_WARNING(0,
+                      "Margo is likely to encounter stack overflows and memory "
+                      "corruption if the Argobots stack size is not large "
+                      "enough to accomodate typical userspace network "
+                      "transport libraries.");
+    }
+    return;
 }
 
 static void set_argobots_environment_variables(struct json_object* config)

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -5,7 +5,8 @@ check_PROGRAMS += \
  tests/unit-tests/margo-init \
  tests/unit-tests/margo-pool \
  tests/unit-tests/margo-abt-pool \
- tests/unit-tests/margo-logging
+ tests/unit-tests/margo-logging \
+ tests/unit-tests/margo-after-abt-init
 
 TESTS += \
  tests/unit-tests/margo-addr \
@@ -13,7 +14,8 @@ TESTS += \
  tests/unit-tests/margo-init \
  tests/unit-tests/margo-pool \
  tests/unit-tests/margo-abt-pool \
- tests/unit-tests/margo-logging
+ tests/unit-tests/margo-logging \
+ tests/unit-tests/margo-after-abt-init
 
 tests_unit_tests_margo_addr_SOURCES = \
  tests/unit-tests/munit/munit.c \
@@ -43,6 +45,11 @@ tests_unit_tests_margo_abt_pool_SOURCES = \
 tests_unit_tests_margo_logging_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-logging.c \
+ tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_after_abt_init_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-after-abt-init.c \
  tests/unit-tests/helper-server.c
 
 endif

--- a/tests/unit-tests/margo-after-abt-init.c
+++ b/tests/unit-tests/margo-after-abt-init.c
@@ -31,6 +31,7 @@ static void* test_context_setup(const MunitParameter params[], void* user_data)
 {
     (void)params;
     (void)user_data;
+    int ret;
 
     struct test_context* ctx = calloc(1, sizeof(*ctx));
     ctx->log_buffer          = calloc(102400, 1);
@@ -45,10 +46,8 @@ static void* test_context_setup(const MunitParameter params[], void* user_data)
     test_logger.error    = test_log_fn;
     test_logger.critical = test_log_fn;
 
-#if 0
     ret = margo_set_global_logger(&test_logger);
     munit_assert_int(ret, ==, 0);
-#endif
 
     return ctx;
 }
@@ -72,6 +71,12 @@ static MunitResult margo_after_abt(const MunitParameter params[], void* data)
 
     ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
     munit_assert_not_null(ctx->mid);
+
+    /* The above should have produced a warning, because margo was unable to
+     * set the desired abt stack settings
+     */
+    munit_assert_int(ctx->log_buffer_pos, >, 0);
+    printf("global log contents: %s\n", ctx->log_buffer);
 
     margo_finalize(ctx->mid);
 

--- a/tests/unit-tests/margo-after-abt-init.c
+++ b/tests/unit-tests/margo-after-abt-init.c
@@ -1,0 +1,92 @@
+
+#include <margo.h>
+#include "helper-server.h"
+#include "munit/munit.h"
+
+struct test_context {
+    margo_instance_id mid;
+    char*             log_buffer;
+    int               log_buffer_pos;
+    int               log_buffer_size;
+};
+
+static void test_log_fn(void* uargs, const char* str)
+{
+    struct test_context* ctx = uargs;
+
+    /* check for overflow */
+    munit_assert_int(strlen(str) + ctx->log_buffer_pos, <,
+                     ctx->log_buffer_size);
+
+    /* directly copy msg to buffer */
+    strcpy(&ctx->log_buffer[ctx->log_buffer_pos], str);
+    ctx->log_buffer_pos += strlen(str);
+
+    return;
+}
+
+struct margo_logger test_logger;
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void)params;
+    (void)user_data;
+
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+    ctx->log_buffer          = calloc(102400, 1);
+    ctx->log_buffer_size     = 102400;
+
+    /* set up custom logger to make it easier to validate output */
+    test_logger.uargs    = ctx;
+    test_logger.trace    = test_log_fn;
+    test_logger.debug    = test_log_fn;
+    test_logger.info     = test_log_fn;
+    test_logger.warning  = test_log_fn;
+    test_logger.error    = test_log_fn;
+    test_logger.critical = test_log_fn;
+
+#if 0
+    ret = margo_set_global_logger(&test_logger);
+    munit_assert_int(ret, ==, 0);
+#endif
+
+    return ctx;
+}
+
+static void test_context_tear_down(void* data)
+{
+    struct test_context* ctx = (struct test_context*)data;
+
+    free(ctx->log_buffer);
+    free(ctx);
+}
+
+static MunitResult margo_after_abt(const MunitParameter params[], void* data)
+{
+    struct test_context* ctx = (struct test_context*)data;
+    char* protocol = "na+sm";
+    int ret;
+
+    ret = ABT_init(0, NULL);
+    munit_assert_int(ret, ==, 0);
+
+    ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    margo_finalize(ctx->mid);
+
+    return MUNIT_OK;
+}
+
+static MunitTest tests[]
+    = {{"/margo-after-abt", margo_after_abt, test_context_setup,
+        test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+       {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+
+static const MunitSuite test_suite
+    = {"/margo", tests, NULL, 1, MUNIT_SUITE_OPTION_NONE};
+
+int main(int argc, char** argv)
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}

--- a/tests/unit-tests/margo-after-abt-init.c
+++ b/tests/unit-tests/margo-after-abt-init.c
@@ -83,8 +83,37 @@ static MunitResult margo_after_abt(const MunitParameter params[], void* data)
     return MUNIT_OK;
 }
 
+static MunitResult margo_after_abt_set_env(const MunitParameter params[], void* data)
+{
+    struct test_context* ctx = (struct test_context*)data;
+    char* protocol = "na+sm";
+    int ret;
+
+    /* In this version, we use a margo utility function to set desired
+     * parameters before calling ABT_init().  This should silence the
+     * warning.
+     */
+    margo_set_environment(NULL);
+
+    ret = ABT_init(0, NULL);
+    munit_assert_int(ret, ==, 0);
+
+    ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    /* check if log is silent */
+    munit_assert_int(ctx->log_buffer_pos, ==, 0);
+
+    margo_finalize(ctx->mid);
+
+    return MUNIT_OK;
+}
+
+
 static MunitTest tests[]
     = {{"/margo-after-abt", margo_after_abt, test_context_setup,
+        test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+      {"/margo-after-abt-set-env", margo_after_abt_set_env, test_context_setup,
         test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
        {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
 


### PR DESCRIPTION
- adds a utility function (`margo_set_environment()`) that can be used to set preferred Argobots parameters for Margo prior to external calls to ABT_init()
- modifies warning to rely on runtime query of Argobots API to confirm settings
- verbose warning message suggesting use of above function if settings are not in alignment
- extra test cases for external initialization of Argobots
- relies on changes that already landed in PR #147 to make sure that warnings are visible by default

Once this is available in a tagged release we should update other repos to use margo_set_environment() rather than manually setting parameters, so that they are future proof in case we change defaults or modify other settings in the future.

Fixes #118 