### PR TITLE
test case for mutex busy spin behavior

### DIFF
--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -6,7 +6,8 @@ check_PROGRAMS += \
  tests/unit-tests/margo-pool \
  tests/unit-tests/margo-abt-pool \
  tests/unit-tests/margo-logging \
- tests/unit-tests/margo-after-abt-init
+ tests/unit-tests/margo-after-abt-init \
+ tests/unit-tests/margo-scheduling
 
 TESTS += \
  tests/unit-tests/margo-addr \
@@ -15,7 +16,8 @@ TESTS += \
  tests/unit-tests/margo-pool \
  tests/unit-tests/margo-abt-pool \
  tests/unit-tests/margo-logging \
- tests/unit-tests/margo-after-abt-init
+ tests/unit-tests/margo-after-abt-init \
+ tests/unit-tests/margo-scheduling
 
 tests_unit_tests_margo_addr_SOURCES = \
  tests/unit-tests/munit/munit.c \
@@ -50,6 +52,11 @@ tests_unit_tests_margo_logging_SOURCES = \
 tests_unit_tests_margo_after_abt_init_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-after-abt-init.c \
+ tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_scheduling_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-scheduling.c \
  tests/unit-tests/helper-server.c
 
 endif

--- a/tests/unit-tests/margo-scheduling.c
+++ b/tests/unit-tests/margo-scheduling.c
@@ -1,0 +1,66 @@
+/*
+ * (C) 2020 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+/* The purpose of these tests are to check the behavior of the Argobots
+ * scheduler in conjunction with Margo in various scenarios
+ */
+
+#include <stdio.h>
+#include <margo.h>
+#include "helper-server.h"
+#include "munit/munit.h"
+
+struct test_context {
+    margo_instance_id mid;
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void) params;
+    (void) user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+
+    char* protocol = "na+sm";
+
+    ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    return ctx;
+}
+
+static void test_context_tear_down(void* fixture)
+{
+    struct test_context* ctx = (struct test_context*)fixture;
+
+    margo_finalize(ctx->mid);
+
+    free(ctx);
+}
+
+static MunitResult test_abt_mutex_cpu(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    /* TODO: do something */
+    return MUNIT_OK;
+}
+
+static MunitTest test_suite_tests[] = {
+    { (char*) "/abt_mutex_cpu", test_abt_mutex_cpu,
+        test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL },
+    { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};
+
+static const MunitSuite test_suite = {
+    (char*) "/margo", test_suite_tests, NULL, 1, MUNIT_SUITE_OPTION_NONE
+};
+
+int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}

--- a/tests/unit-tests/margo-scheduling.c
+++ b/tests/unit-tests/margo-scheduling.c
@@ -10,6 +10,9 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
 #include <margo.h>
 #include "helper-server.h"
 #include "munit/munit.h"
@@ -69,6 +72,9 @@ static MunitResult test_abt_mutex_cpu(const MunitParameter params[], void* data)
     (void)data;
     ABT_pool rpc_pool;
     ABT_thread tid;
+    int ret;
+    struct rusage usage;
+    double user_cpu_seconds;
 
     struct test_context* ctx = (struct test_context*)data;
 
@@ -87,7 +93,12 @@ static MunitResult test_abt_mutex_cpu(const MunitParameter params[], void* data)
     ABT_thread_join(tid);
     ABT_thread_free(&tid);
 
-    /* TODO: measure CPU usage */
+    ret = getrusage(RUSAGE_SELF, &usage);
+    munit_assert_int(ret, ==, 0);
+
+    user_cpu_seconds  = (double)usage.ru_utime.tv_sec + (double)usage.ru_utime.tv_usec / 1000000;
+
+    printf("user CPU time used: %f\n", user_cpu_seconds);
 
     return MUNIT_OK;
 }

--- a/tests/unit-tests/margo-scheduling.c
+++ b/tests/unit-tests/margo-scheduling.c
@@ -101,7 +101,11 @@ static MunitResult test_abt_mutex_cpu(const MunitParameter params[], void* data)
     munit_assert_int(ret, ==, 0);
     user_cpu_seconds2  = (double)usage.ru_utime.tv_sec + (double)usage.ru_utime.tv_usec / 1000000.0;
 
-    printf("user CPU time used: %f\n", user_cpu_seconds2 - user_cpu_seconds1);
+    printf("User CPU time used: %f\n", user_cpu_seconds2 - user_cpu_seconds1);
+    if(user_cpu_seconds2 - user_cpu_seconds1 > 4.0)
+        printf("\tdetected that Argobots mutexes may busy spin.\n");
+    else
+        printf("\tdetected that Argobots mutexes will not busy spin.\n");
 
     return MUNIT_OK;
 }

--- a/tests/unit-tests/margo-scheduling.c
+++ b/tests/unit-tests/margo-scheduling.c
@@ -74,9 +74,13 @@ static MunitResult test_abt_mutex_cpu(const MunitParameter params[], void* data)
     ABT_thread tid;
     int ret;
     struct rusage usage;
-    double user_cpu_seconds;
+    double user_cpu_seconds1, user_cpu_seconds2;
 
     struct test_context* ctx = (struct test_context*)data;
+
+    ret = getrusage(RUSAGE_SELF, &usage);
+    munit_assert_int(ret, ==, 0);
+    user_cpu_seconds1  = (double)usage.ru_utime.tv_sec + (double)usage.ru_utime.tv_usec / 1000000.0;
 
     /* hold mutex while creating ULT */
     ABT_mutex_lock(ctx->mutex);
@@ -95,10 +99,9 @@ static MunitResult test_abt_mutex_cpu(const MunitParameter params[], void* data)
 
     ret = getrusage(RUSAGE_SELF, &usage);
     munit_assert_int(ret, ==, 0);
+    user_cpu_seconds2  = (double)usage.ru_utime.tv_sec + (double)usage.ru_utime.tv_usec / 1000000.0;
 
-    user_cpu_seconds  = (double)usage.ru_utime.tv_sec + (double)usage.ru_utime.tv_usec / 1000000;
-
-    printf("user CPU time used: %f\n", user_cpu_seconds);
+    printf("user CPU time used: %f\n", user_cpu_seconds2 - user_cpu_seconds1);
 
     return MUNIT_OK;
 }


### PR DESCRIPTION
The test case is functional in that it displays the CPU time consumed by 5 seconds of Argobots mutex contention.  See https://github.com/pmodels/argobots/issues/361 for a discussion of the issue.

Before this can be merged we need to:
- [x] decide what the correct mitigation should be
- [x] alter the unit test so that it includes an assertion that the CPU time is less than some threshold (so that it fails in the future if this behavior regresses again)