### PR TITLE
Use ABT_eventual_memory in margo requests

### DIFF
--- a/src/margo-abt-macros.h
+++ b/src/margo-abt-macros.h
@@ -1,0 +1,68 @@
+/*
+ * (C) 2021 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#ifndef __MARGO_ABT_MACROS_H
+#define __MARGO_ABT_MACROS_H
+
+#include <abt.h>
+
+/* In recent versions of Argobots, some new types
+ * have been provided to manipulate mutex, condition
+ * variables, and eventuals on the stack rather than
+ * allocating them on the heap. The following macros
+ * allow to use these new types when available.
+ *
+ * Note: the margo_eventual_t type represents either
+ * an ABT_eventual or an ABT_eventual_memory, but
+ * cannot hold a value.
+ */
+
+#ifdef ABT_EVENTUAL_INITIALIZER
+
+typedef ABT_eventual_memory margo_eventual_t;
+
+static inline int __margo_eventual_create(margo_eventual_t* ev)
+{
+    memset(ev, 0, sizeof(*ev));
+    return ABT_SUCCESS;
+}
+
+    #define MARGO_EVENTUAL_CREATE(__ev__) __margo_eventual_create(__ev__)
+
+    #define MARGO_EVENTUAL_FREE(__ev__)
+
+    #define MARGO_EVENTUAL_WAIT(__ev__) \
+        ABT_eventual_wait(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)), NULL)
+
+    #define MARGO_EVENTUAL_SET(__ev__) \
+        ABT_eventual_set(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)), NULL, 0)
+
+    #define MARGO_EVENTUAL_RESET(__ev__) \
+        ABT_eventual_reset(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)))
+
+    #define MARGO_EVENTUAL_TEST(__ev__, __flag__)                          \
+        ABT_eventual_test(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)), NULL, \
+                          (__flag__))
+
+#else
+
+typedef ABT_eventual margo_eventual_t;
+
+    #define MARGO_EVENTUAL_CREATE(__ev__) ABT_eventual_create(0, (__ev__))
+
+    #define MARGO_EVENTUAL_FREE(__ev__) ABT_eventual_free(__ev__)
+
+    #define MARGO_EVENTUAL_WAIT(__ev__) ABT_eventual_wait((__ev__), NULL)
+
+    #define MARGO_EVENTUAL_SET(__ev__) ABT_eventual_set((__ev__), NULL, 0)
+
+    #define MARGO_EVENTUAL_RESET(__ev__) ABT_eventual_reset(__ev__)
+
+    #define MARGO_EVENTUAL_TEST(__ev__, __flag__) \
+        ABT_eventual_test((__ev__), NULL, (__flag__))
+
+#endif
+
+#endif

--- a/src/margo-abt-macros.h
+++ b/src/margo-abt-macros.h
@@ -19,50 +19,86 @@
  * cannot hold a value.
  */
 
+// Eventuals
+
 #ifdef ABT_EVENTUAL_INITIALIZER
 
 typedef ABT_eventual_memory margo_eventual_t;
 
 static inline int __margo_eventual_create(margo_eventual_t* ev)
 {
-    memset(ev, 0, sizeof(*ev));
+    static const ABT_eventual_memory ev_init = ABT_EVENTUAL_INITIALIZER;
+    memcpy(ev, &ev_init, sizeof(ev_init));
     return ABT_SUCCESS;
 }
+
+    #define MARGO_EVENTUAL_GET_HANDLE(__ev__) \
+        ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__))
 
     #define MARGO_EVENTUAL_CREATE(__ev__) __margo_eventual_create(__ev__)
 
     #define MARGO_EVENTUAL_FREE(__ev__)
 
-    #define MARGO_EVENTUAL_WAIT(__ev__) \
-        ABT_eventual_wait(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)), NULL)
-
-    #define MARGO_EVENTUAL_SET(__ev__) \
-        ABT_eventual_set(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)), NULL, 0)
-
-    #define MARGO_EVENTUAL_RESET(__ev__) \
-        ABT_eventual_reset(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)))
-
-    #define MARGO_EVENTUAL_TEST(__ev__, __flag__)                          \
-        ABT_eventual_test(ABT_EVENTUAL_MEMORY_GET_HANDLE(&(__ev__)), NULL, \
-                          (__flag__))
-
-#else
+#else // ABT_EVENTUAL_INITIALIZED not defined
 
 typedef ABT_eventual margo_eventual_t;
+
+    #define MARGO_EVENTUAL_GET_HANDLE(__ev__) (__ev__)
 
     #define MARGO_EVENTUAL_CREATE(__ev__) ABT_eventual_create(0, (__ev__))
 
     #define MARGO_EVENTUAL_FREE(__ev__) ABT_eventual_free(__ev__)
 
-    #define MARGO_EVENTUAL_WAIT(__ev__) ABT_eventual_wait((__ev__), NULL)
+#endif
 
-    #define MARGO_EVENTUAL_SET(__ev__) ABT_eventual_set((__ev__), NULL, 0)
+#define MARGO_EVENTUAL_WAIT(__ev__) \
+    ABT_eventual_wait(MARGO_EVENTUAL_GET_HANDLE(__ev__), NULL)
 
-    #define MARGO_EVENTUAL_RESET(__ev__) ABT_eventual_reset(__ev__)
+#define MARGO_EVENTUAL_SET(__ev__) \
+    ABT_eventual_set(MARGO_EVENTUAL_GET_HANDLE(__ev__), NULL, 0)
 
-    #define MARGO_EVENTUAL_TEST(__ev__, __flag__) \
-        ABT_eventual_test((__ev__), NULL, (__flag__))
+#define MARGO_EVENTUAL_RESET(__ev__) \
+    ABT_eventual_reset(MARGO_EVENTUAL_GET_HANDLE(__ev__))
+
+#define MARGO_EVENTUAL_TEST(__ev__, __flag__) \
+    ABT_eventual_test(MARGO_EVENTUAL_GET_HANDLE(__ev__), NULL, (__flag__))
+
+// Mutex
+
+#ifdef ABT_MUTEX_INITIALIZER
+
+typedef ABT_mutex_memory margo_mutex_t;
+
+static inline int __margo_mutex_create(margo_mutex_t* mtx)
+{
+    static const ABT_mutex_memory mtx_init = ABT_MUTEX_INITIALIZER;
+    memcpy(mtx, &mtx_init, sizeof(mtx_init));
+    return ABT_SUCCESS;
+}
+
+    #define MARGO_MUTEX_GET_HANDLE(__mtx__) \
+        ABT_MUTEX_MEMORY_GET_HANDLE(&(__mtx__))
+
+    #define MARGO_MUTEX_CREATE(__mtx__) __margo_mutex_create(__mtx__)
+
+    #define MARGO_MUTEX_FREE(__mtx__)
+
+#else // ABT_MUTEX_INITIALIZER not defined
+
+typedef ABT_mutex margo_mutex_t;
+
+    #define MARGO_MUTEX_GET_HANDLE(__mtx__) (__mtx__)
+
+    #define MARGO_MUTEX_CREATE(__mtx__) ABT_mutex_create(__mtx__)
+
+    #define MARGO_MUTEX_FREE(__mtx__) ABT_mutex_free(__mtx__)
 
 #endif
+
+#define MARGO_MUTEX_LOCK(__mtx__) \
+    ABT_mutex_lock(MARGO_MUTEX_GET_HANDLE(__mtx__))
+
+#define MARGO_MUTEX_UNLOCK(__mtx__) \
+    ABT_mutex_unlock(MARGO_MUTEX_GET_HANDLE(__mtx__))
 
 #endif

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -18,6 +18,7 @@
 #include <math.h>
 
 #include "margo.h"
+#include "margo-abt-macros.h"
 #include "margo-logging.h"
 #include "margo-bulk-util.h"
 #include "margo-timer.h"
@@ -158,10 +159,11 @@ struct margo_instance {
 };
 
 struct margo_request_struct {
-    ABT_eventual   eventual;
-    margo_timer_t* timer;
-    hg_handle_t    handle;
-    double         start_time; /* timestamp of when the operation started */
+    margo_eventual_t eventual;
+    hg_return_t      hret;
+    margo_timer_t*   timer;
+    hg_handle_t      handle;
+    double           start_time; /* timestamp of when the operation started */
     uint64_t rpc_breadcrumb; /* statistics tracking identifier, if applicable */
     uint64_t server_addr_hash; /* hash of globally unique string addr of margo
                                   server instance */


### PR DESCRIPTION
This PR enables using ABT_eventual_memory instead of ABT_eventual in margo requests. This allows keeping the eventual on the stack.

I tested with argobots@main (which has ABT_eventual_memory) and with argobots@1.1 (which doesn't) and `make check` passes fine.

@carns I let you take a look and merge if you're satisfied.

Note that this PR also adds a similar mechanism for mutex, but I didn't find any mutex allocated in a critical path so I didn't change anything. One mutex that could be changed is the global mutex (in margo-globals.c), but I think this should be made an ABT_mutex_memory, not something selected based on whether ABT_mutex_memory is available. I think using ABT_mutex_memory would require making margo depend on argobots@1.1 (or an earlier version, but at least I know argobots@1.0 doesn't have them). 