### PR TITLE
limit default tests to sm

### DIFF
--- a/tests/margo-test-sleep.c
+++ b/tests/margo-test-sleep.c
@@ -55,16 +55,10 @@ int main(int argc, char** argv)
     /* use a single pool for progress and sleeper threads */
     /* NOTE: we don't use RPC handlers, so no need for an RPC pool */
     /***************************************/
-    mid = margo_init("tcp", MARGO_CLIENT_MODE, 0, 0);
-    //    margo_set_log_level(mid, MARGO_LOG_TRACE);
-
+    mid = margo_init("sm", MARGO_CLIENT_MODE, 0, 0);
     if (mid == MARGO_INSTANCE_NULL) {
-        /* if tcp didn't work, try sm */
-        mid = margo_init("sm", MARGO_CLIENT_MODE, 0, 0);
-        if (mid == MARGO_INSTANCE_NULL) {
-            fprintf(stderr, "Error: margo_init()\n");
-            return (-1);
-        }
+        fprintf(stderr, "Error: margo_init()\n");
+        return (-1);
     }
 
     /* retrieve current pool to use for ULT creation */

--- a/tests/unit-tests/margo-addr.c
+++ b/tests/unit-tests/margo-addr.c
@@ -270,7 +270,7 @@ static MunitResult test_margo_addr_lookup(const MunitParameter params[], void* d
 }
 
 static char* protocol_params[] = {
-    "na+sm", "ofi+tcp", NULL
+    "na+sm", NULL
 };
 
 static MunitParameterEnum test_params[] = {

--- a/tests/unit-tests/margo-init.c
+++ b/tests/unit-tests/margo-init.c
@@ -72,7 +72,7 @@ static MunitResult init_cycle_client(const MunitParameter params[], void* data)
 }
 
 static char* protocol_params[] = {
-    "na+sm", "ofi+tcp", NULL
+    "na+sm", NULL
 };
 
 static char* use_progress_thread_params[] = {


### PR DESCRIPTION
- tcp isn't necessarily available depending on how Mercury and it's dependencies were compiled