### PR TITLE
relax error code assertion in unit test

### DIFF
--- a/tests/unit-tests/margo-comm-error.c
+++ b/tests/unit-tests/margo-comm-error.c
@@ -129,7 +129,8 @@ static MunitResult test_comm_unreachable(const MunitParameter params[], void* da
 
     /* attempt to send rpc to addr, should fail without timeout */
     hret = margo_forward_timed(handle, NULL, 2000.0);
-    munit_assert_int(hret, ==, HG_NODEV);
+    munit_assert_int(hret, !=, HG_SUCCESS);
+    munit_assert_int(hret, !=, HG_TIMEOUT);
 
     margo_destroy(handle);
 


### PR DESCRIPTION
- rather than checking for a specific error code (which no longer holds
  in mercury 2.1.0rc3), instead just make sure that it is a non-success,
  non-timeout error