### PR TITLE
Added the possibility to throttle incoming RPCs

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -1427,7 +1427,7 @@ int __margo_internal_finalize_requested(margo_instance_id mid);
  *
  * @param mid Margo instance
  */
-void __margo_internal_incr_pending(margo_instance_id mid);
+int __margo_internal_incr_pending(margo_instance_id mid);
 
 /**
  * @private
@@ -1499,14 +1499,13 @@ void __margo_internal_post_wrapper_hooks(margo_instance_id mid);
         margo_destroy(handle);                                                 \
         return (HG_OTHER_ERROR);                                               \
     }                                                                          \
-    if (__margo_internal_finalize_requested(__mid)) {                          \
+    if (__margo_internal_incr_pending(__mid) != 0) {                           \
         margo_warning(__mid,                                                   \
                       "Ignoring " #__name " RPC because margo is finalizing"); \
         margo_destroy(handle);                                                 \
         return (HG_CANCELED);                                                  \
     }                                                                          \
     __pool = margo_hg_handle_get_handler_pool(handle);                         \
-    __margo_internal_incr_pending(__mid);                                      \
     margo_trace(__mid,                                                         \
                 "Spawning ULT for " #__name                                    \
                 " RPC "                                                        \

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -119,7 +119,9 @@ struct margo_instance {
     /* control logic to prevent margo_finalize from destroying
        the instance when some operations are pending */
     unsigned  pending_operations;
+    unsigned  max_pending_operations;
     ABT_mutex pending_operations_mtx;
+    ABT_cond  pending_operations_cv;
     int       finalize_requested;
 
     /* control logic for shutting down */


### PR DESCRIPTION
This PR solves a possible race condition in the `DEFINE_MARGO_RPC_HANDLER` macro and adds the possibility to cap the number of in-flight RPCs to a maximum, configured via the "max_pending_rpcs" field in the Margo JSON configuration (default is 0, meaning no max imposed).

## Fix to DEFINE_MARGO_RPC_HANDLER

This macro is currently calling `__margo_internal_finalize_requested` ([here](https://github.com/mochi-hpc/mochi-margo/blob/main/include/margo.h#L1502)) to check if another RPC currently running has requested margo to shut down. It then calls `__margo_internal_incr_pending` ([here](https://github.com/mochi-hpc/mochi-margo/blob/main/include/margo.h#L1509)) to increment the number of running RPCs. This leaves a small window during which an RPC running in another ES could call `margo_finalize`, complete and finalize the margo instance.

This PR solves this by making the `__margo_internal_incr_pending` return 0 if it correctly incremented the number of pending RPCs, and -1 if finalize was requested, which makes calling `__margo_internal_finalize_requested` unnecessary.

## Throttling beyond a maximum number of RPCs

This PR adds a `max_pending_operations` field in the margo instance, and a condition variable in addition to the existing mutex. If an RPC is received and `pending_operations == max_pending_operations`, the condition variable will make `__margo_internal_incr_pending` block. The condition variable is signaled when the number of pending operations is decreased as existing RPCs terminate.

Note that since `__margo_internal_incr_pending` is called in the context of the RPC handler generated by `DEFINE_MARGO_RPC_HANDLER`, this blocking code is executed within the progress loop, so it will also prevent the progress loop from running. Hence this mechanism is the final throttling mechanism to use when all else (e.g. priority pool, custom schedulers) have failed to properly manage the flow of RPCs.

## Potential problem

I thought about this after posting the PR: because this mechanism will block the progress loop, it can create deadlocks if, for example, RPCs that are executing need the progress loop to be actively running to make progress (e.g. if they have a timer, or if they themselves send RPCs or issue bulk operations). So this might not be very clever in the end... Maybe the right thing to do is, instead of blocking, to make the RPC handler fail with `HG_AGAIN` so that the client is invited to retry the operation later?