### PR TITLE
fixed possible race in DEFINE_RPC_HANDLER macro

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -1427,7 +1427,7 @@ int __margo_internal_finalize_requested(margo_instance_id mid);
  *
  * @param mid Margo instance
  */
-void __margo_internal_incr_pending(margo_instance_id mid);
+int __margo_internal_incr_pending(margo_instance_id mid);
 
 /**
  * @private
@@ -1499,14 +1499,13 @@ void __margo_internal_post_wrapper_hooks(margo_instance_id mid);
         margo_destroy(handle);                                                 \
         return (HG_OTHER_ERROR);                                               \
     }                                                                          \
-    if (__margo_internal_finalize_requested(__mid)) {                          \
+    if (!__margo_internal_incr_pending(__mid)) {                               \
         margo_warning(__mid,                                                   \
                       "Ignoring " #__name " RPC because margo is finalizing"); \
         margo_destroy(handle);                                                 \
         return (HG_CANCELED);                                                  \
     }                                                                          \
     __pool = margo_hg_handle_get_handler_pool(handle);                         \
-    __margo_internal_incr_pending(__mid);                                      \
     margo_trace(__mid,                                                         \
                 "Spawning ULT for " #__name                                    \
                 " RPC "                                                        \

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1585,12 +1585,17 @@ int __margo_internal_finalize_requested(margo_instance_id mid)
     return mid->finalize_requested;
 }
 
-void __margo_internal_incr_pending(margo_instance_id mid)
+int __margo_internal_incr_pending(margo_instance_id mid)
 {
-    if (!mid) return;
+    if (!mid) return 0;
+    int ret = 1;
     ABT_mutex_lock(mid->pending_operations_mtx);
-    mid->pending_operations += 1;
+    if (mid->finalize_requested)
+        ret = 0;
+    else
+        mid->pending_operations += 1;
     ABT_mutex_unlock(mid->pending_operations_mtx);
+    return ret;
 }
 
 void __margo_internal_decr_pending(margo_instance_id mid)


### PR DESCRIPTION
Fix possible race due to checking if margo is finalized then incrementing pending requests.