### PR TITLE
fix race between deregister and incoming rpcs

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -1471,15 +1471,21 @@ void __margo_internal_post_wrapper_hooks(margo_instance_id mid);
 
 #define _handler_for_NULL NULL
 
-#define __MARGO_INTERNAL_RPC_WRAPPER_BODY(__name)                 \
-    margo_instance_id __mid;                                      \
-    __mid = margo_hg_handle_get_instance(handle);                 \
-    __margo_internal_pre_wrapper_hooks(__mid, handle);            \
-    margo_trace(__mid, "Starting RPC " #__name " (handle = %p)",  \
-                (void*)handle);                                   \
-    __name(handle);                                               \
-    margo_trace(__mid, "RPC " #__name " completed (handle = %p)", \
-                (void*)handle);                                   \
+#define __MARGO_INTERNAL_RPC_WRAPPER_BODY(__name)                              \
+    margo_instance_id __mid;                                                   \
+    __mid = margo_hg_handle_get_instance(handle);                              \
+    if (__mid == MARGO_INSTANCE_NULL) {                                        \
+        margo_error(                                                           \
+            __mid, "Could not get margo instance when entering RPC " #__name); \
+        margo_destroy(handle);                                                 \
+        return;                                                                \
+    }                                                                          \
+    __margo_internal_pre_wrapper_hooks(__mid, handle);                         \
+    margo_trace(__mid, "Starting RPC " #__name " (handle = %p)",               \
+                (void*)handle);                                                \
+    __name(handle);                                                            \
+    margo_trace(__mid, "RPC " #__name " completed (handle = %p)",              \
+                (void*)handle);                                                \
     __margo_internal_post_wrapper_hooks(__mid);
 
 #define __MARGO_INTERNAL_RPC_WRAPPER(__name)       \

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1052,6 +1052,10 @@ hg_return_t margo_respond(hg_handle_t handle, void* out_struct)
      * profile */
     struct margo_request_struct* treq;
     margo_instance_id            mid = margo_hg_handle_get_instance(handle);
+    if (mid == NULL) {
+        margo_error(NULL, "Could not get margo instance in margo_respond()");
+        return (HG_OTHER_ERROR);
+    }
     if (mid->profile_enabled) {
         ABT_key_get(g_margo_target_timing_key, (void**)(&treq));
         assert(treq != NULL);
@@ -1155,8 +1159,8 @@ hg_return_t margo_bulk_transfer(margo_instance_id mid,
 {
     struct margo_request_struct reqs;
     hg_return_t                 hret = margo_bulk_itransfer_internal(
-        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
-        local_offset, size, &reqs);
+                        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
+                        local_offset, size, &reqs);
     if (hret != HG_SUCCESS) return hret;
     return margo_wait_internal(&reqs);
 }

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -9,7 +9,8 @@ check_PROGRAMS += \
  tests/unit-tests/margo-logging \
  tests/unit-tests/margo-after-abt-init \
  tests/unit-tests/margo-scheduling \
- tests/unit-tests/margo-comm-error
+ tests/unit-tests/margo-comm-error \
+ tests/unit-tests/margo-comm-finalize
 
 TESTS += \
  tests/unit-tests/margo-addr \
@@ -21,7 +22,8 @@ TESTS += \
  tests/unit-tests/margo-logging \
  tests/unit-tests/margo-after-abt-init \
  tests/unit-tests/margo-scheduling \
- tests/unit-tests/margo-comm-error
+ tests/unit-tests/margo-comm-error \
+ tests/unit-tests/margo-comm-finalize
 
 tests_unit_tests_margo_addr_SOURCES = \
  tests/unit-tests/munit/munit.c \
@@ -71,6 +73,11 @@ tests_unit_tests_margo_scheduling_SOURCES = \
 tests_unit_tests_margo_comm_error_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-comm-error.c \
+ tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_comm_finalize_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-comm-finalize.c \
  tests/unit-tests/helper-server.c
 
 endif

--- a/tests/unit-tests/margo-comm-finalize.c
+++ b/tests/unit-tests/margo-comm-finalize.c
@@ -1,0 +1,173 @@
+/*
+ * (C) 2020 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+/* this unit test is meant to try out various rpc scenarios while a server
+ * is shutting down
+ */
+
+#include <stdio.h>
+#include <margo.h>
+#include "helper-server.h"
+#include "munit/munit.h"
+
+static hg_id_t test_rpc_id;
+
+MERCURY_GEN_PROC(test_rpc_in_t, ((int32_t)(dereg_flag)))
+
+DECLARE_MARGO_RPC_HANDLER(test_rpc_ult)
+
+static void test_rpc_ult(hg_handle_t handle)
+{
+    hg_return_t hret;
+    test_rpc_in_t in;
+    margo_instance_id mid = MARGO_INSTANCE_NULL;
+
+    mid = margo_hg_handle_get_instance(handle);
+    munit_assert_not_null(mid);
+
+    hret = margo_get_input(handle, &in);
+    munit_assert_int(hret, ==, HG_SUCCESS);
+
+    if(in.dereg_flag) {
+        hret = margo_deregister(mid, test_rpc_id);
+        munit_assert_int(hret, ==, HG_SUCCESS);
+    }
+
+    hret = margo_respond(handle, NULL);
+    if(hret != HG_SUCCESS)
+        fprintf(stderr, "margo_respond() failure (expected).\n");
+
+    margo_destroy(handle);
+
+    return;
+}
+DEFINE_MARGO_RPC_HANDLER(test_rpc_ult)
+
+static int svr_init_fn(margo_instance_id mid, void* arg)
+{
+    test_rpc_id
+        = MARGO_REGISTER(mid, "test_rpc", test_rpc_in_t, void, test_rpc_ult);
+
+    return (0);
+}
+
+/* The purpose of this unit test is to check error locations and codes for
+ * particular communication failures
+ */
+
+struct test_context {
+    margo_instance_id mid;
+    int               remote_pid;
+    char              remote_addr[256];
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void)params;
+    (void)user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+
+    const char* protocol         = munit_parameters_get(params, "protocol");
+    hg_size_t   remote_addr_size = 256;
+    ctx->remote_pid = HS_start(protocol, NULL, svr_init_fn, NULL, NULL,
+                               &(ctx->remote_addr[0]), &remote_addr_size);
+    munit_assert_int(ctx->remote_pid, >, 0);
+
+    ctx->mid = margo_init(protocol, MARGO_CLIENT_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    return ctx;
+}
+
+static void test_context_tear_down(void* fixture)
+{
+    struct test_context* ctx = (struct test_context*)fixture;
+
+    hg_addr_t remote_addr = HG_ADDR_NULL;
+    margo_addr_lookup(ctx->mid, ctx->remote_addr, &remote_addr);
+    margo_shutdown_remote_instance(ctx->mid, remote_addr);
+    margo_addr_free(ctx->mid, remote_addr);
+
+    HS_stop(ctx->remote_pid, 0);
+    margo_finalize(ctx->mid);
+
+    free(ctx);
+}
+
+static MunitResult test_comm_deregister(const MunitParameter params[],
+                                        void*                data)
+{
+    (void)params;
+    (void)data;
+    hg_return_t   hret;
+    hg_handle_t   handle_array[64];
+    hg_addr_t     addr;
+    test_rpc_in_t in;
+    margo_request req_array[64];
+    int           i;
+    int           fail_count = 0;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    test_rpc_id
+        = MARGO_REGISTER(ctx->mid, "test_rpc", test_rpc_in_t, void, NULL);
+
+    /* should succeed b/c addr is properly formatted */
+    hret = margo_addr_lookup(ctx->mid, ctx->remote_addr, &addr);
+    munit_assert_int(hret, ==, HG_SUCCESS);
+
+    for (i = 0; i < 64; i++) {
+        hret = margo_create(ctx->mid, addr, test_rpc_id, &handle_array[i]);
+        munit_assert_int(hret, ==, HG_SUCCESS);
+
+        if (i == 16)
+            in.dereg_flag = 1;
+        else
+            in.dereg_flag = 0;
+        hret
+            = margo_iforward_timed(handle_array[i], &in, 2000.0, &req_array[i]);
+        munit_assert_int(hret, ==, HG_SUCCESS);
+    }
+    for (i = 0; i < 64; i++) {
+        hret = margo_wait(req_array[i]);
+        /* NOTE: the above may or may not succeed depending on timing of
+         * deregisteration.  We intentionally do not assert here, though the
+         * expectation is that at least one will fail
+         */
+        if(hret != HG_SUCCESS)
+            fail_count++;
+        margo_destroy(handle_array[i]);
+    }
+
+    /* some subset (not all, but at least one) rpc is expected to have
+     * failed
+     */
+    munit_assert_int(fail_count, >, 0);
+    munit_assert_int(fail_count, <, 64);
+
+    hret = margo_addr_free(ctx->mid, addr);
+    munit_assert_int(hret, ==, HG_SUCCESS);
+
+    return MUNIT_OK;
+}
+
+static char* protocol_params[] = {"na+sm", NULL};
+
+static MunitParameterEnum test_params[]
+    = {{"protocol", protocol_params}, {NULL, NULL}};
+
+static MunitTest test_suite_tests[]
+    = {{(char*)"/comm_deregister", test_comm_deregister, test_context_setup,
+        test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+       {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+
+static const MunitSuite test_suite
+    = {(char*)"/margo", test_suite_tests, NULL, 1, MUNIT_SUITE_OPTION_NONE};
+
+int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)])
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}


### PR DESCRIPTION
- if incoming rpcs are in flight (either about to start a handler, or
  already in a handler) when an rpc is deregistered, then they will fail
  to retrieve the mid pointer associated with the handle because the
  stored pointer has been reset.  Handle this case rather than assuming
  it will always work.
- includes new unit test that deliberately deregisters a handler in the
  middle of a flurry of incoming RPCs