### PR TITLE
Public API to manipulate margo timers

### DIFF
--- a/include/margo-timer.h
+++ b/include/margo-timer.h
@@ -1,0 +1,66 @@
+/*
+ * (C) 2021 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#ifndef __MARGO_TIMER_H
+#define __MARGO_TIMER_H
+
+#include <margo.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*margo_timer_callback_fn)(void*);
+typedef struct margo_timer* margo_timer_t;
+
+/**
+ * @brief Creates a timer object.
+ *
+ * @param mid Margo instance
+ * @param cb_fn Callback to call when the timer finishes
+ * @param cb_dat Callback data
+ * @param timer Resulting timer
+ *
+ * @return 0 on success, negative value on failure
+ */
+int margo_timer_create(margo_instance_id       mid,
+                       margo_timer_callback_fn cb_fn,
+                       void*                   cb_dat,
+                       margo_timer_t*          timer);
+
+/**
+ * @brief Start the timer with a provided timeout.
+ *
+ * @param margo_timer_t Timer object to start
+ * @param timeout_ms Timeout
+ *
+ * @return 0 on success, negative value on failure
+ */
+int margo_timer_start(margo_timer_t timer, double timeout_ms);
+
+/**
+ * @brief Cancel a started timer.
+ *
+ * @param timer Timer to cancel
+ *
+ * @return 0 on success, negative value on failure
+ */
+int margo_timer_cancel(margo_timer_t timer);
+
+/**
+ * @brief Destroys a timer. If the timer was started,
+ * this function will also cancel it.
+ *
+ * @param timer Timer to destroy.
+ *
+ * @return 0 on success, negative value on failure
+ */
+int margo_timer_destroy(margo_timer_t timer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MARGO_TIMER_H */

--- a/include/margo-timer.h
+++ b/include/margo-timer.h
@@ -14,6 +14,7 @@ extern "C" {
 
 typedef void (*margo_timer_callback_fn)(void*);
 typedef struct margo_timer* margo_timer_t;
+#define MARGO_TIMER_NULL ((margo_timer_t)NULL)
 
 /**
  * @brief Creates a timer object.

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -21,7 +21,7 @@
 #include "margo-logging.h"
 #include "margo-instance.h"
 #include "margo-bulk-util.h"
-#include "margo-timer.h"
+#include "margo-timer-private.h"
 #include "utlist.h"
 #include "uthash.h"
 #include "abtx_prof.h"

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1165,8 +1165,8 @@ hg_return_t margo_bulk_transfer(margo_instance_id mid,
 {
     struct margo_request_struct reqs;
     hg_return_t                 hret = margo_bulk_itransfer_internal(
-                        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
-                        local_offset, size, &reqs);
+        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
+        local_offset, size, &reqs);
     if (hret != HG_SUCCESS) return hret;
     return margo_wait_internal(&reqs);
 }
@@ -1263,7 +1263,7 @@ static void margo_thread_sleep_cb(void* arg)
 
 void margo_thread_sleep(margo_instance_id mid, double timeout_ms)
 {
-    margo_timer_t             sleep_timer;
+    margo_timer               sleep_timer;
     margo_thread_sleep_cb_dat sleep_cb_dat;
 
     /* set data needed for sleep callback */

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -21,7 +21,7 @@
 #include "margo-abt-macros.h"
 #include "margo-logging.h"
 #include "margo-bulk-util.h"
-#include "margo-timer.h"
+#include "margo-timer-private.h"
 #include "utlist.h"
 #include "uthash.h"
 

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -161,7 +161,7 @@ struct margo_instance {
 struct margo_request_struct {
     margo_eventual_t eventual;
     hg_return_t      hret;
-    margo_timer_t*   timer;
+    margo_timer*     timer;
     hg_handle_t      handle;
     double           start_time; /* timestamp of when the operation started */
     uint64_t rpc_breadcrumb; /* statistics tracking identifier, if applicable */

--- a/src/margo-timer-private.h
+++ b/src/margo-timer-private.h
@@ -7,18 +7,19 @@
 #ifndef __MARGO_TIMER
 #define __MARGO_TIMER
 
+#include "margo-timer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef void (*margo_timer_cb_fn)(void*);
-
 typedef struct margo_timer {
-    margo_timer_cb_fn   cb_fn;
-    void*               cb_dat;
-    double              expiration;
-    struct margo_timer* next;
-    struct margo_timer* prev;
+    margo_instance_id       mid;
+    margo_timer_callback_fn cb_fn;
+    void*                   cb_dat;
+    double                  expiration;
+    struct margo_timer*     next;
+    struct margo_timer*     prev;
 } margo_timer;
 
 /**
@@ -43,11 +44,11 @@ void __margo_timer_list_free(margo_instance_id        mid,
  * @param [in] cb_dat callback data passed to the callback function
  * @param [in] timeout_ms timeout duration in milliseconds
  */
-void __margo_timer_init(margo_instance_id mid,
-                        margo_timer*      timer,
-                        margo_timer_cb_fn cb_fn,
-                        void*             cb_dat,
-                        double            timeout_ms);
+void __margo_timer_init(margo_instance_id       mid,
+                        margo_timer*            timer,
+                        margo_timer_callback_fn cb_fn,
+                        void*                   cb_dat,
+                        double                  timeout_ms);
 
 /**
  * Destroys a margo timer object which was previously initialized

--- a/src/margo-timer.c
+++ b/src/margo-timer.c
@@ -17,12 +17,12 @@
 
 /* structure for mapping margo instance ids to corresponding timer instances */
 struct margo_timer_list {
-    ABT_mutex      mutex;
-    margo_timer_t* queue_head;
+    ABT_mutex    mutex;
+    margo_timer* queue_head;
 };
 
 static void __margo_timer_queue(struct margo_timer_list* timer_lst,
-                                margo_timer_t*           timer);
+                                margo_timer*             timer);
 
 struct margo_timer_list* __margo_timer_list_create()
 {
@@ -40,9 +40,9 @@ struct margo_timer_list* __margo_timer_list_create()
 void __margo_timer_list_free(margo_instance_id        mid,
                              struct margo_timer_list* timer_lst)
 {
-    margo_timer_t* cur;
-    ABT_pool       handler_pool;
-    int            ret;
+    margo_timer* cur;
+    ABT_pool     handler_pool;
+    int          ret;
 
     ABT_mutex_lock(timer_lst->mutex);
     /* delete any remaining timers from the queue */
@@ -74,7 +74,7 @@ void __margo_timer_list_free(margo_instance_id        mid,
 }
 
 void __margo_timer_init(margo_instance_id mid,
-                        margo_timer_t*    timer,
+                        margo_timer*      timer,
                         margo_timer_cb_fn cb_fn,
                         void*             cb_dat,
                         double            timeout_ms)
@@ -96,7 +96,7 @@ void __margo_timer_init(margo_instance_id mid,
     return;
 }
 
-void __margo_timer_destroy(margo_instance_id mid, margo_timer_t* timer)
+void __margo_timer_destroy(margo_instance_id mid, margo_timer* timer)
 {
     struct margo_timer_list* timer_lst;
 
@@ -114,7 +114,7 @@ void __margo_timer_destroy(margo_instance_id mid, margo_timer_t* timer)
 void __margo_check_timers(margo_instance_id mid)
 {
     int                      ret;
-    margo_timer_t*           cur;
+    margo_timer*             cur;
     struct margo_timer_list* timer_lst;
     ABT_pool                 handler_pool;
     double                   now;
@@ -176,9 +176,9 @@ int __margo_timer_get_next_expiration(margo_instance_id mid,
 }
 
 static void __margo_timer_queue(struct margo_timer_list* timer_lst,
-                                margo_timer_t*           timer)
+                                margo_timer*             timer)
 {
-    margo_timer_t* cur;
+    margo_timer* cur;
 
     ABT_mutex_lock(timer_lst->mutex);
 

--- a/src/margo-timer.h
+++ b/src/margo-timer.h
@@ -13,13 +13,13 @@ extern "C" {
 
 typedef void (*margo_timer_cb_fn)(void*);
 
-typedef struct margo_timed_element {
-    margo_timer_cb_fn           cb_fn;
-    void*                       cb_dat;
-    double                      expiration;
-    struct margo_timed_element* next;
-    struct margo_timed_element* prev;
-} margo_timer_t;
+typedef struct margo_timer {
+    margo_timer_cb_fn   cb_fn;
+    void*               cb_dat;
+    double              expiration;
+    struct margo_timer* next;
+    struct margo_timer* prev;
+} margo_timer;
 
 /**
  * Creates a margo_timer_list.
@@ -44,7 +44,7 @@ void __margo_timer_list_free(margo_instance_id        mid,
  * @param [in] timeout_ms timeout duration in milliseconds
  */
 void __margo_timer_init(margo_instance_id mid,
-                        margo_timer_t*    timer,
+                        margo_timer*      timer,
                         margo_timer_cb_fn cb_fn,
                         void*             cb_dat,
                         double            timeout_ms);
@@ -54,7 +54,7 @@ void __margo_timer_init(margo_instance_id mid,
  * @param [in] mid Margo instance
  * @param [in] timer pointer to margo timer object to be destroyed
  */
-void __margo_timer_destroy(margo_instance_id mid, margo_timer_t* timer);
+void __margo_timer_destroy(margo_instance_id mid, margo_timer* timer);
 
 /**
  * Checks for expired timers and performs specified timeout action

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -8,6 +8,7 @@ check_PROGRAMS += \
  tests/unit-tests/margo-eventual \
  tests/unit-tests/margo-logging \
  tests/unit-tests/margo-after-abt-init \
+ tests/unit-tests/margo-timer \
  tests/unit-tests/margo-scheduling \
  tests/unit-tests/margo-comm-error \
  tests/unit-tests/margo-comm-finalize
@@ -21,6 +22,7 @@ TESTS += \
  tests/unit-tests/margo-eventual \
  tests/unit-tests/margo-logging \
  tests/unit-tests/margo-after-abt-init \
+ tests/unit-tests/margo-timer \
  tests/unit-tests/margo-scheduling \
  tests/unit-tests/margo-comm-error \
  tests/unit-tests/margo-comm-finalize
@@ -79,5 +81,9 @@ tests_unit_tests_margo_comm_finalize_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-comm-finalize.c \
  tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_timer_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-timer.c
 
 endif

--- a/tests/unit-tests/margo-timer.c
+++ b/tests/unit-tests/margo-timer.c
@@ -1,0 +1,169 @@
+/*
+ * (C) 2020 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#include <stdio.h>
+#include <margo.h>
+#include <margo-timer.h>
+#include "munit/munit.h"
+
+inline int to_bool(const char* v)
+{
+    if (strcmp(v, "true") == 0) return 1;
+    if (strcmp(v, "false") == 0) return 0;
+    return -1;
+}
+
+struct test_context {
+    margo_instance_id mid;
+    int               flag;
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void)params;
+    (void)user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+
+    const char* protocol = munit_parameters_get(params, "protocol");
+
+    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    return ctx;
+}
+
+static void test_context_tear_down(void* fixture)
+{
+    struct test_context* ctx = (struct test_context*)fixture;
+    margo_finalize(ctx->mid);
+    free(ctx);
+}
+
+static void timer_cb(void* data)
+{
+    struct test_context* ctx = (struct test_context*)data;
+    ctx->flag                = 1;
+}
+
+static MunitResult test_margo_timer_start(const MunitParameter params[],
+                                          void*                data)
+{
+    (void)params;
+    (void)data;
+    int           ret;
+    margo_timer_t timer = MARGO_TIMER_NULL;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    ret = margo_timer_create(ctx->mid, timer_cb, data, &timer);
+    munit_assert_int(ret, ==, 0);
+    munit_assert_not_null(timer);
+
+    ctx->flag = 0;
+
+    ret = margo_timer_start(timer, 500);
+    munit_assert_int(ret, ==, 0);
+
+    // second start should fail
+    ret = margo_timer_start(timer, 500);
+    munit_assert_int(ret, ==, -1);
+
+    margo_thread_sleep(ctx->mid, 1000);
+
+    munit_assert_int(ctx->flag, ==, 1);
+
+    ret = margo_timer_destroy(timer);
+    munit_assert_int(ret, ==, 0);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_margo_timer_cancel(const MunitParameter params[],
+                                           void*                data)
+{
+    (void)params;
+    (void)data;
+    int           ret;
+    margo_timer_t timer = MARGO_TIMER_NULL;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    ret = margo_timer_create(ctx->mid, timer_cb, data, &timer);
+    munit_assert_int(ret, ==, 0);
+    munit_assert_not_null(timer);
+
+    ctx->flag = 0;
+
+    ret = margo_timer_start(timer, 500);
+    munit_assert_int(ret, ==, 0);
+
+    margo_thread_sleep(ctx->mid, 100);
+
+    ret = margo_timer_cancel(timer);
+    munit_assert_int(ret, ==, 0);
+
+    margo_thread_sleep(ctx->mid, 900);
+
+    munit_assert_int(ctx->flag, ==, 0);
+
+    ret = margo_timer_destroy(timer);
+    munit_assert_int(ret, ==, 0);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_margo_timer_destroy(const MunitParameter params[],
+                                            void*                data)
+{
+    (void)params;
+    (void)data;
+    int           ret;
+    margo_timer_t timer = MARGO_TIMER_NULL;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    ret = margo_timer_create(ctx->mid, timer_cb, data, &timer);
+    munit_assert_int(ret, ==, 0);
+    munit_assert_not_null(timer);
+
+    ctx->flag = 0;
+
+    ret = margo_timer_start(timer, 500);
+    munit_assert_int(ret, ==, 0);
+
+    margo_thread_sleep(ctx->mid, 100);
+
+    ret = margo_timer_destroy(timer);
+    munit_assert_int(ret, ==, 0);
+
+    margo_thread_sleep(ctx->mid, 900);
+
+    munit_assert_int(ctx->flag, ==, 0);
+
+    return MUNIT_OK;
+}
+
+static char* protocol_params[] = {"na+sm", NULL};
+
+static MunitParameterEnum test_params[]
+    = {{"protocol", protocol_params}, {NULL, NULL}};
+
+static MunitTest test_suite_tests[] = {
+    {(char*)"/margo_timer/start", test_margo_timer_start, test_context_setup,
+     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    {(char*)"/margo_timer/cancel", test_margo_timer_cancel, test_context_setup,
+     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    {(char*)"/margo_timer/destroy", test_margo_timer_destroy,
+     test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE,
+     test_params},
+    {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+
+static const MunitSuite test_suite
+    = {(char*)"/margo", test_suite_tests, NULL, 1, MUNIT_SUITE_OPTION_NONE};
+
+int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)])
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}


### PR DESCRIPTION
Margo timers are currently used only to handle timeout of margo_forward, but they could be pretty useful on their own. This PR adds the margo-timer.h header with 4 functions to create, start, cancel, and destroy timers. It also adds the corresponding unit tests.