### PR TITLE
optional margo_bulk_create_attr() wrapper

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -980,6 +980,35 @@ hg_return_t margo_bulk_create(margo_instance_id mid,
                               hg_uint8_t        flags,
                               hg_bulk_t*        handle);
 
+#if (HG_VERSION_MAJOR > 2) || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR > 1) \
+    || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR == 1                        \
+        && HG_VERSION_PATCH > 0)
+/**
+ * Same as bulk create, but with an additional attrs argument for memory
+ * attributes.
+ *
+ * \param [in] mid          Margo instance
+ * \param [in] count        number of segments
+ * \param [in] buf_ptrs     array of pointers
+ * \param [in] buf_sizes    array of sizes
+ * \param [in] flags        permission flag:
+ *                             - HG_BULK_READWRITE
+ *                             - HG_BULK_READ_ONLY
+ *                             - HG_BULK_WRITE_ONLY
+ * \param [in] attrs        bulk attributes
+ * \param [out] handle      pointer to returned abstract bulk handle
+ *
+ * \return HG_SUCCESS or corresponding HG error code
+ */
+hg_return_t margo_bulk_create_attr(margo_instance_id          mid,
+                                   hg_uint32_t                count,
+                                   void**                     buf_ptrs,
+                                   const hg_size_t*           buf_sizes,
+                                   hg_uint8_t                 flags,
+                                   const struct hg_bulk_attr* attrs,
+                                   hg_bulk_t*                 handle);
+#endif
+
 /**
  * Free bulk handle.
  *

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1248,6 +1248,33 @@ hg_return_t margo_bulk_create(margo_instance_id mid,
     return (hret);
 }
 
+#if (HG_VERSION_MAJOR > 2) || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR > 1) \
+    || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR == 1                        \
+        && HG_VERSION_PATCH > 0)
+hg_return_t margo_bulk_create_attr(margo_instance_id          mid,
+                                   hg_uint32_t                count,
+                                   void**                     buf_ptrs,
+                                   const hg_size_t*           buf_sizes,
+                                   hg_uint8_t                 flags,
+                                   const struct hg_bulk_attr* attrs,
+                                   hg_bulk_t*                 handle)
+{
+    hg_return_t hret;
+    double      tm1, tm2;
+    int         diag_enabled = mid->diag_enabled;
+
+    if (diag_enabled) tm1 = ABT_get_wtime();
+    hret = HG_Bulk_create_attr(mid->hg_class, count, buf_ptrs, buf_sizes, flags,
+                               attrs, handle);
+    if (diag_enabled) {
+        tm2 = ABT_get_wtime();
+        __DIAG_UPDATE(mid->diag_bulk_create_elapsed, (tm2 - tm1));
+    }
+
+    return (hret);
+}
+#endif
+
 hg_return_t margo_bulk_free(hg_bulk_t handle) { return (HG_Bulk_free(handle)); }
 
 hg_return_t margo_bulk_deserialize(margo_instance_id mid,

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -9,6 +9,7 @@ check_PROGRAMS += \
  tests/unit-tests/margo-logging \
  tests/unit-tests/margo-after-abt-init \
  tests/unit-tests/margo-timer \
+ tests/unit-tests/margo-bulk \
  tests/unit-tests/margo-scheduling \
  tests/unit-tests/margo-comm-error \
  tests/unit-tests/margo-comm-finalize
@@ -22,7 +23,7 @@ TESTS += \
  tests/unit-tests/margo-eventual \
  tests/unit-tests/margo-logging \
  tests/unit-tests/margo-after-abt-init \
- tests/unit-tests/margo-timer \
+ tests/unit-tests/margo-bulk \
  tests/unit-tests/margo-scheduling \
  tests/unit-tests/margo-comm-error \
  tests/unit-tests/margo-comm-finalize
@@ -85,6 +86,10 @@ tests_unit_tests_margo_comm_finalize_SOURCES = \
 tests_unit_tests_margo_timer_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-timer.c
+
+tests_unit_tests_margo_bulk_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-bulk.c
 
 noinst_HEADERS += tests/unit-tests/munit/munit.h \
                   tests/unit-tests/helper-server.h

--- a/tests/unit-tests/margo-bulk.c
+++ b/tests/unit-tests/margo-bulk.c
@@ -1,0 +1,122 @@
+/*
+ * (C) 2022 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#include <stdio.h>
+#include <margo.h>
+#include "munit/munit.h"
+
+struct test_context {
+    margo_instance_id mid;
+    int               flag;
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void)params;
+    (void)user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+
+    const char* protocol = munit_parameters_get(params, "protocol");
+
+    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    return ctx;
+}
+
+static void test_context_tear_down(void* fixture)
+{
+    struct test_context* ctx = (struct test_context*)fixture;
+    margo_finalize(ctx->mid);
+    free(ctx);
+}
+
+#if (HG_VERSION_MAJOR > 2) || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR > 1) \
+    || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR == 1                        \
+        && HG_VERSION_PATCH > 0)
+static MunitResult test_margo_bulk_create_attr(const MunitParameter params[],
+                                               void*                data)
+{
+    (void)params;
+    (void)data;
+    int          ret;
+    hg_size_t    size;
+    void*        buffer;
+    hg_bulk_t    bulk_handle;
+    struct hg_bulk_attr bulk_attr;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    size   = 512;
+    buffer = calloc(1, 512);
+    munit_assert_not_null(buffer);
+    bulk_attr.mem_type = NA_MEM_TYPE_HOST;
+
+    ret = margo_bulk_create_attr(ctx->mid, 1, &buffer, &size, HG_BULK_READWRITE,
+                                 &bulk_attr, &bulk_handle);
+    munit_assert_int(ret, ==, 0);
+
+    ret = margo_bulk_free(bulk_handle);
+    munit_assert_int(ret, ==, 0);
+
+    free(buffer);
+
+    return MUNIT_OK;
+}
+#endif
+
+static MunitResult test_margo_bulk_create(const MunitParameter params[],
+                                          void*                data)
+{
+    (void)params;
+    (void)data;
+    int       ret;
+    hg_size_t size;
+    void*     buffer;
+    hg_bulk_t bulk_handle;
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    size   = 512;
+    buffer = calloc(1, 512);
+    munit_assert_not_null(buffer);
+
+    ret = margo_bulk_create(ctx->mid, 1, &buffer, &size, HG_BULK_READWRITE,
+                            &bulk_handle);
+    munit_assert_int(ret, ==, 0);
+
+    ret = margo_bulk_free(bulk_handle);
+    munit_assert_int(ret, ==, 0);
+
+    free(buffer);
+
+    return MUNIT_OK;
+}
+
+static char* protocol_params[] = {"na+sm", NULL};
+
+static MunitParameterEnum test_params[]
+    = {{"protocol", protocol_params}, {NULL, NULL}};
+
+static MunitTest test_suite_tests[]
+    = {{(char*)"/margo_bulk/bulk_create", test_margo_bulk_create,
+        test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE,
+        test_params},
+#if (HG_VERSION_MAJOR > 2) || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR > 1) \
+    || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR == 1                        \
+        && HG_VERSION_PATCH > 0)
+       {(char*)"/margo_bulk/bulk_create_attr", test_margo_bulk_create_attr,
+        test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE,
+        test_params},
+#endif
+       {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+
+static const MunitSuite test_suite
+    = {(char*)"/margo", test_suite_tests, NULL, 1, MUNIT_SUITE_OPTION_NONE};
+
+int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)])
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}


### PR DESCRIPTION
Do not merge until https://github.com/mercury-hpc/mercury/pull/559 lands and we can validate what mercury version number to key off of in the #if guards.

Fixes #184 