### PR TITLE
Reworked serialization mechanism to add a custom header embedding error codes

### DIFF
--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -22,6 +22,7 @@
 #include "margo-instance.h"
 #include "margo-bulk-util.h"
 #include "margo-timer-private.h"
+#include "margo-serialization.h"
 #include "utlist.h"
 #include "uthash.h"
 #include "abtx_prof.h"
@@ -859,15 +860,19 @@ static hg_return_t margo_provider_iforward_internal(
     hg_bool_t is_registered;
     ret = HG_Registered(hgi->hg_class, id, &is_registered);
     if (ret != HG_SUCCESS) return (ret);
+
     if (!is_registered) {
+
         /* if Mercury does not recognize this ID (with provider id included)
          * then register it now
          */
         /* find encoders for base ID */
-        ret = HG_Registered_proc_cb(hgi->hg_class, hgi->id, &flag, &in_cb,
-                                    &out_cb);
-        if (ret != HG_SUCCESS) return (ret);
-        if (!flag) return (HG_NO_MATCH);
+        struct margo_rpc_data* rpc_data
+            = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class,
+                                                         hgi->id);
+        if (!rpc_data) return HG_NO_MATCH;
+        in_cb  = rpc_data->in_proc_cb;
+        out_cb = rpc_data->out_proc_cb;
 
         /* find out if disable_response was called for this RPC */
         hg_bool_t response_disabled;
@@ -882,7 +887,15 @@ static hg_return_t margo_provider_iforward_internal(
         ret = HG_Registered_disable_response(hgi->hg_class, id,
                                              response_disabled);
         if (ret != HG_SUCCESS) return (ret);
+
+    } else {
+        // it is registered, we still need to extract in_cb for later
+        struct margo_rpc_data* rpc_data
+            = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class, id);
+        if (!rpc_data) return HG_NO_MATCH;
+        in_cb = rpc_data->in_proc_cb;
     }
+
     ret = HG_Reset(handle, hgi->addr, id);
     if (ret != HG_SUCCESS) return (ret);
 
@@ -931,7 +944,11 @@ static hg_return_t margo_provider_iforward_internal(
             req->server_addr_hash); /*record server address in the breadcrumb */
     }
 
-    hret = HG_Forward(handle, margo_cb, (void*)req, in_struct);
+    // create the margo_forward_proc_args for the serializer
+    struct margo_forward_proc_args forward_args
+        = {.user_args = (void*)in_struct, .user_cb = in_cb};
+
+    hret = HG_Forward(handle, margo_cb, (void*)req, (void*)&forward_args);
 
     if (hret != HG_SUCCESS) { MARGO_EVENTUAL_FREE(&eventual); }
     /* remove timer if HG_Forward failed */
@@ -1041,7 +1058,15 @@ margo_irespond_internal(hg_handle_t   handle,
                         void*         out_struct,
                         margo_request req) /* should have been allocated */
 {
-    int ret;
+    int                   ret;
+    hg_proc_cb_t          out_cb = NULL;
+    const struct hg_info* hgi    = HG_Get_info(handle);
+
+    struct margo_rpc_data* rpc_data
+        = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class, hgi->id);
+    if (!rpc_data) return HG_NO_MATCH;
+    out_cb = rpc_data->out_proc_cb;
+
     ret = MARGO_EVENTUAL_CREATE(&(req->eventual));
     if (ret != 0) { return (HG_NOMEM_ERROR); }
     req->handle         = handle;
@@ -1049,7 +1074,31 @@ margo_irespond_internal(hg_handle_t   handle,
     req->start_time     = ABT_get_wtime();
     req->rpc_breadcrumb = 0;
 
-    return HG_Respond(handle, margo_cb, (void*)req, out_struct);
+    // create the margo_respond_proc_args for the serializer
+    struct margo_respond_proc_args respond_args
+        = {.user_args = (void*)out_struct,
+           .user_cb   = out_cb,
+           .header    = {.hg_ret = HG_SUCCESS}};
+
+    return HG_Respond(handle, margo_cb, (void*)req, (void*)&respond_args);
+}
+
+void __margo_respond_with_error(hg_handle_t handle, hg_return_t hg_ret)
+{
+    int                   ret;
+    hg_proc_cb_t          out_cb = NULL;
+    const struct hg_info* hgi    = HG_Get_info(handle);
+
+    hg_bool_t   b;
+    hg_return_t hret
+        = HG_Registered_disabled_response(hgi->hg_class, hgi->id, &b);
+    if (hret != HG_SUCCESS) return;
+    if (b) return;
+
+    struct margo_respond_proc_args respond_args
+        = {.user_args = NULL, .user_cb = NULL, .header = {.hg_ret = hg_ret}};
+
+    HG_Respond(handle, NULL, NULL, (void*)&respond_args);
 }
 
 hg_return_t margo_respond(hg_handle_t handle, void* out_struct)
@@ -1093,6 +1142,82 @@ margo_irespond(hg_handle_t handle, void* out_struct, margo_request* req)
     }
     *req = tmp_req;
     return HG_SUCCESS;
+}
+
+hg_return_t margo_get_input(hg_handle_t handle, void* in_struct)
+{
+    hg_proc_cb_t          in_cb = NULL;
+    const struct hg_info* hgi   = HG_Get_info(handle);
+
+    struct margo_rpc_data* rpc_data
+        = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class, hgi->id);
+    if (!rpc_data) return HG_NO_MATCH;
+    in_cb = rpc_data->in_proc_cb;
+
+    // create the margo_forward_proc_args for the serializer
+    struct margo_forward_proc_args forward_args
+        = {.user_args = (void*)in_struct, .user_cb = in_cb, .header = {}};
+
+    return HG_Get_input(handle, (void*)&forward_args);
+}
+
+hg_return_t margo_free_input(hg_handle_t handle, void* in_struct)
+{
+    hg_proc_cb_t          in_cb = NULL;
+    const struct hg_info* hgi   = HG_Get_info(handle);
+
+    struct margo_rpc_data* rpc_data
+        = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class, hgi->id);
+    if (!rpc_data) return HG_NO_MATCH;
+    in_cb = rpc_data->in_proc_cb;
+
+    // create the margo_forward_proc_args for the serializer
+    struct margo_forward_proc_args forward_args
+        = {.user_args = (void*)in_struct, .user_cb = in_cb, .header = {}};
+
+    return HG_Free_input(handle, (void*)&forward_args);
+}
+
+hg_return_t margo_get_output(hg_handle_t handle, void* out_struct)
+{
+    hg_proc_cb_t          out_cb = NULL;
+    const struct hg_info* hgi    = HG_Get_info(handle);
+
+    struct margo_rpc_data* rpc_data
+        = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class, hgi->id);
+    if (!rpc_data) return HG_NO_MATCH;
+    out_cb = rpc_data->out_proc_cb;
+
+    // create the margo_respond_proc_args for the serializer
+    struct margo_respond_proc_args respond_args
+        = {.user_args = (void*)out_struct,
+           .user_cb   = out_cb,
+           .header    = {.hg_ret = HG_SUCCESS}};
+
+    hg_return_t hret = HG_Get_output(handle, (void*)&respond_args);
+    if (hret != HG_SUCCESS)
+        return hret;
+    else
+        return respond_args.header.hg_ret;
+}
+
+hg_return_t margo_free_output(hg_handle_t handle, void* out_struct)
+{
+    hg_proc_cb_t          out_cb = NULL;
+    const struct hg_info* hgi    = HG_Get_info(handle);
+
+    struct margo_rpc_data* rpc_data
+        = (struct margo_rpc_data*)HG_Registered_data(hgi->hg_class, hgi->id);
+    if (!rpc_data) return HG_NO_MATCH;
+    out_cb = rpc_data->out_proc_cb;
+
+    // create the margo_respond_proc_args for the serializer
+    struct margo_respond_proc_args respond_args
+        = {.user_args = (void*)out_struct,
+           .user_cb   = out_cb,
+           .header    = {.hg_ret = HG_SUCCESS}};
+
+    return HG_Free_output(handle, (void*)&respond_args);
 }
 
 hg_return_t margo_bulk_create(margo_instance_id mid,
@@ -1166,8 +1291,8 @@ hg_return_t margo_bulk_transfer(margo_instance_id mid,
 {
     struct margo_request_struct reqs;
     hg_return_t                 hret = margo_bulk_itransfer_internal(
-                        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
-                        local_offset, size, &reqs);
+        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
+        local_offset, size, &reqs);
     if (hret != HG_SUCCESS) return hret;
     return margo_wait_internal(&reqs);
 }
@@ -1574,7 +1699,8 @@ static hg_id_t margo_register_internal(margo_instance_id mid,
     struct margo_rpc_data* margo_data;
     hg_return_t            hret;
 
-    hret = HG_Register(mid->hg_class, id, in_proc_cb, out_proc_cb, rpc_cb);
+    hret = HG_Register(mid->hg_class, id, margo_forward_proc,
+                       margo_respond_proc, rpc_cb);
     if (hret != HG_SUCCESS) return (hret);
 
     /* register the margo data with the RPC */
@@ -1585,6 +1711,8 @@ static hg_id_t margo_register_internal(margo_instance_id mid,
         if (!margo_data) return (0);
         margo_data->mid                = mid;
         margo_data->pool               = pool;
+        margo_data->in_proc_cb         = in_proc_cb;
+        margo_data->out_proc_cb        = out_proc_cb;
         margo_data->user_data          = NULL;
         margo_data->user_free_callback = NULL;
         hret = HG_Register_data(mid->hg_class, id, margo_data,

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -846,7 +846,6 @@ static hg_return_t margo_provider_iforward_internal(
     const struct hg_info* hgi;
     hg_id_t               id;
     hg_proc_cb_t          in_cb, out_cb;
-    hg_bool_t             flag;
     margo_instance_id     mid = margo_hg_handle_get_instance(handle);
     uint64_t*             rpc_breadcrumb;
     char                  addr_string[128];
@@ -1085,9 +1084,7 @@ margo_irespond_internal(hg_handle_t   handle,
 
 void __margo_respond_with_error(hg_handle_t handle, hg_return_t hg_ret)
 {
-    int                   ret;
-    hg_proc_cb_t          out_cb = NULL;
-    const struct hg_info* hgi    = HG_Get_info(handle);
+    const struct hg_info* hgi = HG_Get_info(handle);
 
     hg_bool_t   b;
     hg_return_t hret

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1207,7 +1207,9 @@ hg_return_t margo_get_output(hg_handle_t handle, void* out_struct)
     if (hret != HG_SUCCESS)
         return hret;
     else
-        return respond_args.header.hg_ret;
+        hret = respond_args.header.hg_ret;
+    if (hret != HG_SUCCESS) HG_Free_output(handle, (void*)&respond_args);
+    return hret;
 }
 
 hg_return_t margo_free_output(hg_handle_t handle, void* out_struct)

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -175,6 +175,8 @@ struct margo_request_struct {
 struct margo_rpc_data {
     margo_instance_id mid;
     ABT_pool          pool;
+    hg_proc_cb_t      in_proc_cb;  /* user-provided input proc */
+    hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
     void*             user_data;
     void (*user_free_callback)(void*);
 };

--- a/src/margo-serialization.h
+++ b/src/margo-serialization.h
@@ -1,0 +1,73 @@
+/*
+ * (C) 2022 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#ifndef __MARGO_SERIALIZATION_H
+#define __MARGO_SERIALIZATION_H
+
+#include "margo.h"
+
+// This file provides the serialization mechanism that Margo injects into
+// Mercury in order to add a header to every RPC and response.
+//
+// Instead of calling HG_Register with user-provided proc callbacks, we call
+// it with margo_forward_proc and margo_respond_proc, and attach the actual
+// user- provided callback using HG_Register_data (see margo_rpc_data struct in
+// margo-instance.h).
+//
+// Once it's time to call HG_Forward or HG_Respond, we extract the user-provided
+// callbacks from the RPC data, create a margo_forward_proc_args or a
+// margo_respond_proc_args structure, initialize it with the user-provided data
+// pointer, and call HG_Forward/Respond with that argument instead.
+//
+// The margo_respond_proc_args structure carries an error code that allows
+// margo to propagate an hg_return_t value to the client. It is used e.g.
+// in the __MARGO_INTERNAL_RPC_HANDLER_BODY macro when something happened
+// that prevented the RPC from running. It allows to not care about the
+// semantics of the user-provided data, since any value other than HG_SUCCESS
+// will make serialization stop at the error code.
+
+typedef struct margo_forward_proc_args {
+    void*        user_args;
+    hg_proc_cb_t user_cb;
+    struct {
+        // nothing here yet
+    } header;
+} * margo_forward_proc_args_t;
+
+typedef struct margo_respond_proc_args {
+    void*        user_args;
+    hg_proc_cb_t user_cb;
+    struct {
+        hg_return_t hg_ret;
+    } header;
+} * margo_respond_proc_args_t;
+
+static inline hg_return_t margo_forward_proc(hg_proc_t proc, void* args)
+{
+    margo_forward_proc_args_t sargs = (margo_forward_proc_args_t)args;
+    hg_return_t               ret   = HG_SUCCESS;
+    ret = hg_proc_memcpy(proc, (void*)(&sargs->header), sizeof(sargs->header));
+    if (ret != HG_SUCCESS) return ret;
+    if (sargs && sargs->user_cb) {
+        ret = sargs->user_cb(proc, sargs->user_args);
+        return ret;
+    } else
+        return HG_SUCCESS;
+}
+
+static inline hg_return_t margo_respond_proc(hg_proc_t proc, void* args)
+{
+    margo_respond_proc_args_t sargs = (margo_respond_proc_args_t)args;
+    hg_return_t               ret
+        = hg_proc_memcpy(proc, (void*)(&sargs->header), sizeof(sargs->header));
+    if (ret != HG_SUCCESS) return ret;
+    if (sargs->header.hg_ret != HG_SUCCESS) return HG_SUCCESS;
+    if (sargs && sargs->user_cb) {
+        return sargs->user_cb(proc, sargs->user_args);
+    } else
+        return HG_SUCCESS;
+}
+
+#endif


### PR DESCRIPTION
This PR changes the way serialization is done in Margo: instead of relying on the user-provided proc callbacks, these proc callbacks are attached to the RPC data. The generic `margo_forward_proc` and `margo_respond_proc` functions, defined in margo-serialization.h, are used instead when registering RPCs. These functions are being passed a structure that includes (1) the user-provided proc callback, (2) the user-provided data, and (3) a header to append to the buffer.

In the case of the response, the header contains an `hg_return_t` error code that, if set to something else than `HG_SUCCESS`, will abort the serialization and forward just that error code back to the client. The error code will then be returned by `margo_get_output` when the client tries to deserialize the output.

This mechanism allowed to add more robustness to the `__MARGO_INTERNAL_RPC_HANDLER_BODY` macro: instead of simply displaying an error message and destroying the handle if something happens (which would leave the client hanging), the `__margo_respond_with_error` function is called to send a response to the client with an `hg_return_t` error code in its header.

Right now I chose the following convention for error codes:
- `HG_NOENTRY` is returned if the margo instance was not found (I have never seen a scenario where this happened, though);
- `HG_PERMISSION` is returned if the margo instance is currently finalizing;
- `HG_OTHER_ERROR` is returned if ABT_thread_create failed to create the ULT for the RPC;

In the future, we can use this mechanism to add limits on the number of RPC running (both RPCs of a certain type as well as total number of RPC), and I envision using `HG_AGAIN` in these cases.