### PR TITLE
report in json if abt lazy stack allocation is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,20 @@ AC_MSG_RESULT(no)
 AC_MSG_ERROR([ABT_SCHED_BASIC_WAIT not available in Argobots])
 )
 
+# check if this version of Argobots supports querying lazy stack allocation
+# status
+AC_MSG_CHECKING(for ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC in Argobots)
+AC_TRY_COMPILE([
+#include <abt.h>
+], [
+enum ABT_info_query_kind query_kind = ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC;
+],
+AC_MSG_RESULT(yes)
+AC_DEFINE(HAVE_ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC, 1, [can query lazy stack alloc support]),
+AC_MSG_RESULT(no)
+)
+
+
 AC_ARG_ENABLE(coverage,
               [AS_HELP_STRING([--enable-coverage],[Enable code coverage @<:@default=no@:>@])],
               [case "${enableval}" in

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1325,8 +1325,8 @@ hg_return_t margo_bulk_transfer(margo_instance_id mid,
 {
     struct margo_request_struct reqs;
     hg_return_t                 hret = margo_bulk_itransfer_internal(
-        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
-        local_offset, size, &reqs);
+                        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
+                        local_offset, size, &reqs);
     if (hret != HG_SUCCESS) return hret;
     return margo_wait_internal(&reqs);
 }

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -1523,7 +1523,8 @@ static int create_xstream_from_config(struct json_object*          es_config,
 static void confirm_argobots_configuration(struct json_object* config)
 {
     /* this function assumes that the json is already fully populated */
-    size_t runtime_abt_thread_stacksize = 0;
+    size_t   runtime_abt_thread_stacksize = 0;
+    ABT_bool config_bool;
 
     /* retrieve expected values according to Margo configuration */
     struct json_object* argobots = json_object_object_get(config, "argobots");
@@ -1554,6 +1555,12 @@ static void confirm_argobots_configuration(struct json_object* config)
             "transport libraries.",
             abt_thread_stacksize, runtime_abt_thread_stacksize);
     }
+
+    /* also simply report a few relevant compile-time parameters */
+    ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC,
+                          &config_bool);
+    CONFIG_OVERRIDE_BOOL(argobots, "lazy_stack_alloc", config_bool,
+                         "argobots.lazy_stack_alloc", 0);
     return;
 }
 

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -1557,10 +1557,14 @@ static void confirm_argobots_configuration(struct json_object* config)
     }
 
     /* also simply report a few relevant compile-time parameters */
+
+#ifdef HAVE_ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC
     ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC,
                           &config_bool);
     CONFIG_OVERRIDE_BOOL(argobots, "lazy_stack_alloc", config_bool,
                          "argobots.lazy_stack_alloc", 0);
+#endif
+
     return;
 }
 


### PR DESCRIPTION
This adds a `"lazy_stack_alloc":true` boolean to the argobots json object in margo to indicate if lazy stack allocation is enabled in Argobots, based on a runtime query.

The boolean is not displayed at all if Argobots does not expose this query parameter.