### PR TITLE
library path workaround

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,12 @@ fi
 PKG_CHECK_MODULES([MERCURY],[mercury],[],
    [AC_MSG_ERROR([Could not find working mercury installation!])])
 LIBS="$MERCURY_LIBS $LIBS"
+# explicitly pass -R <lib path> to libtool so that it sets an rpath/runpath
+# to refer to this dependent library.  This is a workaround to set explicit
+# paths for dependent libraries installed via spack packages, which do not
+# use system library paths, do not install .la files, and do not set
+# LD_LIBRARY_PATH by default.
+LDFLAGS="$LDFLAGS -R "`pkg-config --libs-only-L mercury| sed -e 's/^-L//g'`
 CPPFLAGS="$MERCURY_CFLAGS $CPPFLAGS"
 CFLAGS="$MERCURY_CFLAGS $CFLAGS"
 # find the path containing the Mercury libraries
@@ -85,12 +91,24 @@ AC_SUBST([MERCURY_LIB_PATH], ["$MERCURY_LIB_PATH"])
 PKG_CHECK_MODULES([ARGOBOTS],[argobots],[],
    [AC_MSG_ERROR([Could not find working argobots installation!])])
 LIBS="$ARGOBOTS_LIBS $LIBS"
+# explicitly pass -R <lib path> to libtool so that it sets an rpath/runpath
+# to refer to this dependent library.  This is a workaround to set explicit
+# paths for dependent libraries installed via spack packages, which do not
+# use system library paths, do not install .la files, and do not set
+# LD_LIBRARY_PATH by default.
+LDFLAGS="$LDFLAGS -R "`pkg-config --libs-only-L argobots| sed -e 's/^-L//g'`
 CPPFLAGS="$ARGOBOTS_CFLAGS $CPPFLAGS"
 CFLAGS="$ARGOBOTS_CFLAGS $CFLAGS"
 
 PKG_CHECK_MODULES([JSONC],[json-c],[],
    [AC_MSG_ERROR([Could not find working json-c installation!])])
 LIBS="$JSONC_LIBS $LIBS"
+# explicitly pass -R <lib path> to libtool so that it sets an rpath/runpath
+# to refer to this dependent library.  This is a workaround to set explicit
+# paths for dependent libraries installed via spack packages, which do not
+# use system library paths, do not install .la files, and do not set
+# LD_LIBRARY_PATH by default.
+LDFLAGS="$LDFLAGS -R "`pkg-config --libs-only-L json-c| sed -e 's/^-L//g'`
 dnl
 dnl Note that pkg-config may report an include path that contains a
 dnl "/json-c" component.  If so, strip it out.  We prefer to use an explicit


### PR DESCRIPTION
This modifies the autoconf script to explicitly pass along rpath information for dependent libraries to libtool via the -R option.  It resolves runtime "library not found" errors when linked against dependencies that were installed via spack origin/develop as of 2022-08-16.

This works, but I'm not sure if it's a good solution.  It may not cover all cases, and a similar strategy would need to be repeated in any external autotools software packages that rely on our libraries (for example, imagine an app that in turns relies on a libmargo library installed by spack and will need to set an rpath to refer to it).

This is only needed now due to a policy change in spack that prevents it from automatically exporting LD_LIBRARY_PATH for loaded packages.

@mdorier 