### PR TITLE
add support for na.request_mem_device

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -167,6 +167,7 @@ margo_instance_id margo_init(const char* addr_str,
  *       "stats" : false,
  *       "na_no_block" : false,
  *       "na_no_retry" : false,
+ *       "na_request_mem_device" : false,
  *       "max_contexts" : 1,
  *       "ip_subnet" : "",
  *       "auth_key" : ""

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -572,6 +572,7 @@ validate_and_complete_config(struct json_object*        _margo,
        - [optional] stats: bool (default false)
        - [optional] na_no_block: bool (default false)
        - [optional] na_no_retry: bool (default false)
+       - [optional] na_request_mem_device: bool (default false)
        - [optional] max_contexts: integer (default 1)
        - [optional] ip_subnet: string (added only if found in provided
        hg_init_info)
@@ -694,6 +695,20 @@ validate_and_complete_config(struct json_object*        _margo,
         CONFIG_HAS_OR_CREATE(_mercury, boolean, "na_no_retry", 0,
                              "mercury.na_no_retry", val);
         MARGO_TRACE(0, "mercury.na_no_retry = %s",
+                    json_object_get_boolean(val) ? "true" : "false");
+    }
+
+    { // add mercury.na_request_mem_device or set it as default
+        if (_hg_init_info) {
+            bool na_request_mem_device
+                = _hg_init_info->na_init_info.request_mem_device;
+            CONFIG_OVERRIDE_BOOL(_mercury, "na_request_mem_device",
+                                 na_request_mem_device,
+                                 "mercury.na_request_mem_device", 1);
+        }
+        CONFIG_HAS_OR_CREATE(_mercury, boolean, "na_request_mem_device", 0,
+                             "mercury.na_request_mem_device", val);
+        MARGO_TRACE(0, "mercury.na_request_mem_device = %s",
                     json_object_get_boolean(val) ? "true" : "false");
     }
 
@@ -1300,6 +1315,9 @@ static void fill_hg_init_info_from_config(struct json_object*  config,
         info->na_init_info.progress_mode |= NA_NO_BLOCK;
     if (json_object_get_boolean(json_object_object_get(hg, "na_no_retry")))
         info->na_init_info.progress_mode |= NA_NO_RETRY;
+    if (json_object_get_boolean(
+            json_object_object_get(hg, "na_request_mem_device")))
+        info->na_init_info.request_mem_device = HG_TRUE;
     info->na_init_info.max_contexts
         = json_object_get_int64(json_object_object_get(hg, "max_contexts"));
     /* The na_init_info max_unexpected_size nad max_expected_size first


### PR DESCRIPTION
New json parameter to enable Mercury support for RDMA to device memory.

Can be enabled with a Margo json config block that looks like this:
```
{
  "mercury":{
    "na_request_mem_device":true
  }
}
```
Fixes #194