### PR TITLE
Fixing munit tests hanging after a failure

### DIFF
--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -3,6 +3,7 @@
 #include <margo.h>
 #include "helper-server.h"
 #include "munit/munit.h"
+#include "munit/munit-goto.h"
 
 /* the intent of these unit tests is to verify the ability to modify various
  * argobots pool settings
@@ -60,24 +61,27 @@ static MunitResult rpc_pool_kind(const MunitParameter params[], void* data)
     mii.json_config = munit_parameters_get(params, "json");
 
     ctx->mid = margo_init_ext(protocol, MARGO_SERVER_MODE, &mii);
-    munit_assert_not_null(ctx->mid);
+    munit_assert_not_null_goto(ctx->mid, error);
 
     /* check resulting configuration */
     runtime_config = margo_get_config(ctx->mid);
 
     /* just one pool with the __rpc__ name */
     count = count_occurrence(runtime_config, "__rpc__");
-    munit_assert_int(count, ==, 1);
+    munit_assert_int_goto(count, ==, 1, error);
 
     /* just one pool with the prio_wait kind */
     count = count_occurrence(runtime_config, "prio_wait");
-    munit_assert_int(count, ==, 1);
+    munit_assert_int_goto(count, ==, 1, error);
 
     free(runtime_config);
 
     margo_finalize(ctx->mid);
 
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static char * json_params[] = {

--- a/tests/unit-tests/margo-forward.c
+++ b/tests/unit-tests/margo-forward.c
@@ -7,22 +7,14 @@
 #include <margo.h>
 #include "helper-server.h"
 #include "munit/munit.h"
+#include "munit/munit-goto.h"
 
-/*
-static hg_id_t rpc_id;
-static hg_id_t provider_rpc_id;
-static hg_id_t null_rpc_id;
-*/
 
 DECLARE_MARGO_RPC_HANDLER(rpc_ult)
 static void rpc_ult(hg_handle_t handle)
 {
-    hg_return_t hret;
-
-    hret = margo_respond(handle, NULL);
-    munit_assert_int(hret, ==, HG_SUCCESS);
+    margo_respond(handle, NULL);
     margo_destroy(handle);
-
     return;
 }
 DEFINE_MARGO_RPC_HANDLER(rpc_ult)
@@ -54,6 +46,9 @@ static void* test_context_setup(const MunitParameter params[], void* user_data)
     munit_assert_int(ctx->remote_pid, >, 0);
 
     ctx->mid = margo_init(protocol, MARGO_SERVER_MODE, 0, 0);
+    if(!ctx->mid) {
+        HS_stop(ctx->remote_pid, 0);
+    }
     munit_assert_not_null(ctx->mid);
 
     return ctx;
@@ -101,12 +96,15 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_SUCCESS);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static MunitResult test_forward_to_null(const MunitParameter params[],
@@ -138,12 +136,15 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_NO_MATCH);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_NO_MATCH, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static MunitResult test_self_forward_to_null(const MunitParameter params[],
@@ -174,12 +175,15 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_NO_MATCH);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_NO_MATCH, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static MunitResult test_forward_invalid(const MunitParameter params[],
@@ -210,13 +214,15 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_NO_MATCH);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
-
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_NO_MATCH, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static MunitResult test_provider_forward(const MunitParameter params[],
@@ -247,13 +253,16 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_SUCCESS);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
 
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static MunitResult test_provider_forward_invalid(const MunitParameter params[],
@@ -284,12 +293,15 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_NO_MATCH);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_NO_MATCH, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static MunitResult test_self_provider_forward_invalid(const MunitParameter params[],
@@ -322,12 +334,15 @@ cleanup:
     hret[4] = margo_addr_free(ctx->mid, addr);
 
 check:
-    munit_assert_int(hret[0], ==, HG_SUCCESS);
-    munit_assert_int(hret[1], ==, HG_SUCCESS);
-    munit_assert_int(hret[2], ==, HG_NO_MATCH);
-    munit_assert_int(hret[3], ==, HG_SUCCESS);
-    munit_assert_int(hret[4], ==, HG_SUCCESS);
+    munit_assert_int_goto(hret[0], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[1], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[2], ==, HG_NO_MATCH, error);
+    munit_assert_int_goto(hret[3], ==, HG_SUCCESS, error);
+    munit_assert_int_goto(hret[4], ==, HG_SUCCESS, error);
     return MUNIT_OK;
+
+error:
+    return MUNIT_FAIL;
 }
 
 static char* protocol_params[] = {"ofi+tcp", NULL};
@@ -338,18 +353,18 @@ static MunitParameterEnum test_params[]
 static MunitTest test_suite_tests[] = {
     {(char*)"/forward", test_forward, test_context_setup,
      test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
-//    {(char*)"/forward_to_null", test_forward_to_null, test_context_setup,
-//     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
-//    {(char*)"/self_forward_to_null", test_self_forward_to_null, test_context_setup,
-//     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    {(char*)"/forward_to_null", test_forward_to_null, test_context_setup,
+     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    {(char*)"/self_forward_to_null", test_self_forward_to_null, test_context_setup,
+     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
     {(char*)"/forward_invalid", test_forward_invalid, test_context_setup,
      test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
     {(char*)"/provider_forward", test_provider_forward, test_context_setup,
      test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
     {(char*)"/provider_forward_invalid", test_provider_forward_invalid, test_context_setup,
      test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
-//    {(char*)"/self_provider_forward_invalid", test_self_provider_forward_invalid, test_context_setup,
-//     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    {(char*)"/self_provider_forward_invalid", test_self_provider_forward_invalid, test_context_setup,
+     test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
     {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
 
 static const MunitSuite test_suite

--- a/tests/unit-tests/munit/munit-goto.h
+++ b/tests/unit-tests/munit/munit-goto.h
@@ -1,0 +1,199 @@
+#ifndef MUNIT_GOTO_H
+#define MUNIT_GOTO_H
+
+#include "munit.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define munit_assert_goto(expr, label) \
+  do { \
+    if (!MUNIT_LIKELY(expr)) { \
+      munit_log(MUNIT_LOG_ERROR, "assertion failed: " #expr); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_true_goto(expr, label) \
+  do { \
+    if (!MUNIT_LIKELY(expr)) { \
+      munit_log(MUNIT_LOG_ERROR, "assertion failed: " #expr " is not true"); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_false_goto(expr, label) \
+  do { \
+    if (!MUNIT_LIKELY(!(expr))) { \
+      munit_log(MUNIT_LOG_ERROR, "assertion failed: " #expr " is not false"); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_type_full_goto(prefix, suffix, T, fmt, a, op, b, label)   \
+  do { \
+    T munit_tmp_a_ = (a); \
+    T munit_tmp_b_ = (b); \
+    if (!(munit_tmp_a_ op munit_tmp_b_)) {                               \
+      munit_logf(MUNIT_LOG_ERROR, \
+            "assertion failed: %s %s %s (" prefix "%" fmt suffix " %s " prefix "%" fmt suffix ")", \
+                   #a, #op, #b, munit_tmp_a_, #op, munit_tmp_b_); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_type_goto(T, fmt, a, op, b, label) \
+  munit_assert_type_full_goto("", "", T, fmt, a, op, b, label)
+
+#define munit_assert_char_goto(a, op, b, label) \
+  munit_assert_type_full_goto("'\\x", "'", char, "02" MUNIT_CHAR_MODIFIER "x", a, op, b, label)
+#define munit_assert_uchar_goto(a, op, b, label) \
+  munit_assert_type_full_goto("'\\x", "'", unsigned char, "02" MUNIT_CHAR_MODIFIER "x", a, op, b, label)
+#define munit_assert_short_goto(a, op, b, label) \
+  munit_assert_type_goto(short, MUNIT_SHORT_MODIFIER "d", a, op, b, label)
+#define munit_assert_ushort_goto(a, op, b, label) \
+  munit_assert_type_goto(unsigned short, MUNIT_SHORT_MODIFIER "u", a, op, b, label)
+#define munit_assert_int_goto(a, op, b, label) \
+  munit_assert_type_goto(int, "d", a, op, b, label)
+#define munit_assert_uint_goto(a, op, b, label) \
+  munit_assert_type_goto(unsigned int, "u", a, op, b, label)
+#define munit_assert_long_goto(a, op, b, label) \
+  munit_assert_type_goto(long int, "ld", a, op, b, label)
+#define munit_assert_ulong_goto(a, op, b, label) \
+  munit_assert_type_goto(unsigned long int, "lu", a, op, b, label)
+#define munit_assert_llong_goto(a, op, b, label) \
+  munit_assert_type_goto(long long int, "lld", a, op, b, label)
+#define munit_assert_ullong_goto(a, op, b, label) \
+  munit_assert_type_goto(unsigned long long int, "llu", a, op, b, label)
+
+#define munit_assert_size_goto(a, op, b, label) \
+  munit_assert_type_goto(size_t, MUNIT_SIZE_MODIFIER "u", a, op, b, label)
+
+#define munit_assert_float_goto(a, op, b, label) \
+  munit_assert_type_goto(float, "f", a, op, b, label)
+#define munit_assert_double_goto(a, op, b, label) \
+  munit_assert_type_goto(double, "g", a, op, b, label)
+#define munit_assert_ptr_goto(a, op, b, label) \
+  munit_assert_type_goto(const void*, "p", a, op, b, label)
+
+#define munit_assert_int8_goto(a, op, b, label)             \
+  munit_assert_type_goto(munit_int8_t, PRIi8, a, op, b, label)
+#define munit_assert_uint8_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_uint8_t, PRIu8, a, op, b, label)
+#define munit_assert_int16_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_int16_t, PRIi16, a, op, b, label)
+#define munit_assert_uint16_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_uint16_t, PRIu16, a, op, b, label)
+#define munit_assert_int32_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_int32_t, PRIi32, a, op, b, label)
+#define munit_assert_uint32_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_uint32_t, PRIu32, a, op, b, label)
+#define munit_assert_int64_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_int64_t, PRIi64, a, op, b, label)
+#define munit_assert_uint64_goto(a, op, b, label) \
+  munit_assert_type_goto(munit_uint64_t, PRIu64, a, op, b, label)
+
+#define munit_assert_double_equal_goto(a, b, precision, label) \
+  do { \
+    const double munit_tmp_a_ = (a); \
+    const double munit_tmp_b_ = (b); \
+    const double munit_tmp_diff_ = ((munit_tmp_a_ - munit_tmp_b_) < 0) ? \
+      -(munit_tmp_a_ - munit_tmp_b_) : \
+      (munit_tmp_a_ - munit_tmp_b_); \
+    if (MUNIT_UNLIKELY(munit_tmp_diff_ > 1e-##precision)) { \
+      munit_logf(MUNIT_LOG_ERROR, \
+        "assertion failed: %s == %s (%0." #precision "g == %0." #precision "g)", \
+        #a, #b, munit_tmp_a_, munit_tmp_b_); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#include <string.h>
+#define munit_assert_string_equa_gotol(a, b, label) \
+  do { \
+    const char* munit_tmp_a_ = a; \
+    const char* munit_tmp_b_ = b; \
+    if (MUNIT_UNLIKELY(strcmp(munit_tmp_a_, munit_tmp_b_) != 0)) { \
+      munit_logf(MUNIT_LOG_ERROR, \
+        "assertion failed: string %s == %s (\"%s\" == \"%s\")", \
+        #a, #b, munit_tmp_a_, munit_tmp_b_); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_string_not_equal_goto(a, b, label) \
+  do { \
+    const char* munit_tmp_a_ = a; \
+    const char* munit_tmp_b_ = b; \
+    if (MUNIT_UNLIKELY(strcmp(munit_tmp_a_, munit_tmp_b_) == 0)) { \
+      munit_logf(MUNIT_LOG_ERROR, \
+        "assertion failed: string %s != %s (\"%s\" == \"%s\")", \
+        #a, #b, munit_tmp_a_, munit_tmp_b_); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_memory_equal_goto(size, a, b, label) \
+  do { \
+    const unsigned char* munit_tmp_a_ = (const unsigned char*) (a); \
+    const unsigned char* munit_tmp_b_ = (const unsigned char*) (b); \
+    const size_t munit_tmp_size_ = (size); \
+    if (MUNIT_UNLIKELY(memcmp(munit_tmp_a_, munit_tmp_b_, munit_tmp_size_)) != 0) { \
+      size_t munit_tmp_pos_; \
+      for (munit_tmp_pos_ = 0 ; munit_tmp_pos_ < munit_tmp_size_ ; munit_tmp_pos_++) { \
+        if (munit_tmp_a_[munit_tmp_pos_] != munit_tmp_b_[munit_tmp_pos_]) { \
+          munit_logf(MUNIT_LOG_ERROR, \
+            "assertion failed: memory %s == %s, at offset %" MUNIT_SIZE_MODIFIER "u", \
+            #a, #b, munit_tmp_pos_); \
+          goto label; \
+        } \
+      } \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_memory_not_equal_goto(size, a, b, label) \
+  do { \
+    const unsigned char* munit_tmp_a_ = (const unsigned char*) (a); \
+    const unsigned char* munit_tmp_b_ = (const unsigned char*) (b); \
+    const size_t munit_tmp_size_ = (size); \
+    if (MUNIT_UNLIKELY(memcmp(munit_tmp_a_, munit_tmp_b_, munit_tmp_size_)) == 0) { \
+      munit_logf(MUNIT_LOG_ERROR, \
+        "assertion failed: memory %s != %s (%zu bytes)", \
+        #a, #b, munit_tmp_size_); \
+      goto label; \
+    } \
+    MUNIT_PUSH_DISABLE_MSVC_C4127_ \
+  } while (0) \
+  MUNIT_POP_DISABLE_MSVC_C4127_
+
+#define munit_assert_ptr_equal_goto(a, b, label) \
+  munit_assert_ptr_goto(a, ==, b, label)
+#define munit_assert_ptr_not_equal_goto(a, b, label) \
+  munit_assert_ptr_goto(a, !=, b, label)
+#define munit_assert_null_goto(ptr, label) \
+  munit_assert_ptr_goto(ptr, ==, NULL, label)
+#define munit_assert_not_null_goto(ptr, label) \
+  munit_assert_ptr_goto(ptr, !=, NULL, label)
+#define munit_assert_ptr_null_goto(ptr, label) \
+  munit_assert_ptr_goto(ptr, ==, NULL, label)
+#define munit_assert_ptr_not_null_goto(ptr, label) \
+  munit_assert_ptr_goto(ptr, !=, NULL, label)
+
+#endif

--- a/tests/unit-tests/munit/munit.c
+++ b/tests/unit-tests/munit/munit.c
@@ -146,7 +146,7 @@
 /*** Logging ***/
 
 static MunitLogLevel munit_log_level_visible = MUNIT_LOG_INFO;
-static MunitLogLevel munit_log_level_fatal = MUNIT_LOG_ERROR;
+static MunitLogLevel munit_log_level_fatal = MUNIT_LOG_ERROR+1;
 
 #if defined(MUNIT_THREAD_LOCAL)
 static MUNIT_THREAD_LOCAL munit_bool munit_error_jmp_buf_valid = 0;


### PR DESCRIPTION
This PR provides `munit_assert_*_goto` macro that take an extra `label` argument and do a `goto label` instead of a `longjump`. This allows to stay in the test and manually return `MUNIT_FAIL` after that label. Some of the unit tests have been updated as examples.