### PR TITLE
fixed problem where sending invalid RPC would return HG_SUCCESS

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -1721,7 +1721,7 @@ void __margo_respond_with_error(hg_handle_t handle, hg_return_t ret);
         BOOST_PP_CAT(hg_proc_, __out_t), _handler_for_##__handler,   \
         __provider_id, __pool);
 
-#define _handler_for_NULL NULL
+hg_return_t _handler_for_NULL(hg_handle_t);
 
 #define __MARGO_INTERNAL_RPC_WRAPPER_BODY(__name)                              \
     margo_instance_id __mid;                                                   \

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -886,7 +886,8 @@ static hg_return_t margo_provider_iforward_internal(
 
         /* register new ID that includes provider id */
         ret = margo_register_internal(margo_hg_info_get_instance(hgi), id,
-                                      in_cb, out_cb, NULL, ABT_POOL_NULL);
+                                      in_cb, out_cb, _handler_for_NULL,
+                                      ABT_POOL_NULL);
         if (ret == 0) return (HG_OTHER_ERROR);
         ret = HG_Registered_disable_response(hgi->hg_class, id,
                                              response_disabled);
@@ -1325,8 +1326,8 @@ hg_return_t margo_bulk_transfer(margo_instance_id mid,
 {
     struct margo_request_struct reqs;
     hg_return_t                 hret = margo_bulk_itransfer_internal(
-                        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
-                        local_offset, size, &reqs);
+        mid, op, origin_addr, origin_handle, origin_offset, local_handle,
+        local_offset, size, &reqs);
     if (hret != HG_SUCCESS) return hret;
     return margo_wait_internal(&reqs);
 }
@@ -1896,4 +1897,11 @@ hg_return_t check_error_in_output(hg_handle_t handle)
     hret = respond_args.header.hg_ret;
     HG_Free_output(handle, (void*)&respond_args);
     return hret;
+}
+
+hg_return_t _handler_for_NULL(hg_handle_t handle)
+{
+    __margo_respond_with_error(handle, HG_NOENTRY);
+    margo_destroy(handle);
+    return HG_SUCCESS;
 }

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -551,6 +551,7 @@ hg_id_t margo_provider_register_name(margo_instance_id mid,
     int                          ret;
     struct margo_registered_rpc* tmp_rpc;
 
+    if (!rpc_cb) rpc_cb = _handler_for_NULL;
     id = gen_id(func_name, provider_id);
 
     /* track information about this rpc registration for debugging and


### PR DESCRIPTION
This PR fixes https://github.com/mochi-hpc/mochi-margo/issues/202.

The solution is actually simple and does not require us to wait for a fix in Mercury: since we already had a `_handler_for_NULL = NULL` defined in our macro to handle the case `MARGO_REGISTER(... NULL)`, I just needed to give it an actual definition in which I can return an `HG_NOENTRY` via the response.

This makes the margo-forward unit test pass.