### PR TITLE
Replace the use of HG_Registered_data with HG_Get_data

### DIFF
--- a/examples/composition/data-xfer-service.c
+++ b/examples/composition/data-xfer-service.c
@@ -32,7 +32,7 @@ static void data_xfer_read_ult(hg_handle_t handle)
     assert(hret == HG_SUCCESS);
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
 #if 0

--- a/examples/composition/delegator-service.c
+++ b/examples/composition/delegator-service.c
@@ -36,7 +36,7 @@ static void delegator_read_ult(hg_handle_t handle)
     assert(hret == HG_SUCCESS);
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
 #if 0

--- a/examples/multiplex/svc1-server.c
+++ b/examples/multiplex/svc1-server.c
@@ -28,7 +28,7 @@ static void svc1_do_thing_ult(hg_handle_t handle)
     assert(hret == HG_SUCCESS);
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     ABT_xstream_self(&my_xstream);
@@ -85,7 +85,7 @@ static void svc1_do_other_thing_ult(hg_handle_t handle)
     assert(hret == HG_SUCCESS);
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     ABT_xstream_self(&my_xstream);

--- a/examples/multiplex/svc2-server.c
+++ b/examples/multiplex/svc2-server.c
@@ -28,7 +28,7 @@ static void svc2_do_thing_ult(hg_handle_t handle)
     assert(hret == HG_SUCCESS);
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     ABT_xstream_self(&my_xstream);
@@ -85,7 +85,7 @@ static void svc2_do_other_thing_ult(hg_handle_t handle)
     assert(hret == HG_SUCCESS);
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     ABT_xstream_self(&my_xstream);

--- a/examples/my-rpc.c
+++ b/examples/my-rpc.c
@@ -47,10 +47,10 @@ static void my_rpc_ult(hg_handle_t handle)
     buffer = calloc(1, 512);
     assert(buffer);
 
-    /* get handle info and margo instance */
     hgi = margo_get_info(handle);
     assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    /* get margo instance */
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     if (in.dump_state) {

--- a/include/margo.h
+++ b/include/margo.h
@@ -1373,6 +1373,32 @@ hg_context_t* margo_get_context(margo_instance_id mid);
 hg_class_t* margo_get_class(margo_instance_id mid);
 
 /**
+ * @brief Get the data that was associated with the handle using
+ * margo_set_data.
+ *
+ * @param h Handle.
+ *
+ * @return Data associated with the handle (NULL is no data attached).
+ */
+void* margo_get_data(hg_handle_t h);
+
+/**
+ * @brief Attach data with the handle. Any previously-attached data will
+ * be freed using the previously-attached free_callback, before being
+ * replaced with the new data.
+ *
+ * The free_callback with be called when the handle is destroyed.
+ *
+ * @param h Handle.
+ * @param data Data to attach.
+ * @param free_callback Free callback.
+ *
+ * @return HG_SUCCESS or HG error code.
+ */
+hg_return_t
+margo_set_data(hg_handle_t h, void* data, void (*free_callback)(void*));
+
+/**
  * @brief Get the margo_instance_id from a received RPC handle.
  *
  * @param [in] h RPC handle.

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1910,8 +1910,8 @@ hg_return_t __margo_internal_set_handle_data(hg_handle_t handle)
     if (!rpc_data) return HG_OTHER_ERROR;
     struct margo_handle_data* handle_data;
     handle_data               = HG_Get_data(handle);
-    bool handle_data_attached = handle_data;
-    if (!handle_data_attached) handle_data = calloc(1, sizeof(*handle_data));
+    bool handle_data_attached = handle_data != NULL;
+    if (!handle_data) handle_data = calloc(1, sizeof(*handle_data));
     handle_data->mid         = rpc_data->mid;
     handle_data->pool        = rpc_data->pool;
     handle_data->in_proc_cb  = rpc_data->in_proc_cb;

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1234,6 +1234,32 @@ hg_return_t margo_free_output(hg_handle_t handle, void* out_struct)
     return HG_Free_output(handle, (void*)&respond_args);
 }
 
+void* margo_get_data(hg_handle_t h)
+{
+    struct margo_handle_data* handle_data
+        = (struct margo_handle_data*)HG_Get_data(h);
+    if (!handle_data) return NULL;
+
+    return handle_data->user_data;
+}
+
+hg_return_t
+margo_set_data(hg_handle_t h, void* data, void (*free_callback)(void*))
+{
+    struct margo_handle_data* handle_data
+        = (struct margo_handle_data*)HG_Get_data(h);
+    if (!handle_data) return HG_NO_MATCH;
+
+    if (handle_data->user_free_callback) {
+        handle_data->user_free_callback(handle_data->user_data);
+    }
+
+    handle_data->user_data          = data;
+    handle_data->user_free_callback = free_callback;
+
+    return HG_SUCCESS;
+}
+
 hg_return_t margo_bulk_create(margo_instance_id mid,
                               hg_uint32_t       count,
                               void**            buf_ptrs,

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1518,13 +1518,7 @@ margo_instance_id margo_hg_info_get_instance(const struct hg_info* info)
 
 margo_instance_id margo_hg_handle_get_instance(hg_handle_t h)
 {
-    struct margo_rpc_data* data;
-    const struct hg_info*  info;
-
-    info = HG_Get_info(h);
-    if (!info) return MARGO_INSTANCE_NULL;
-
-    data = (struct margo_rpc_data*)HG_Registered_data(info->hg_class, info->id);
+    struct margo_handle_data* data = (struct margo_handle_data*)HG_Get_data(h);
     if (!data) return MARGO_INSTANCE_NULL;
 
     return data->mid;

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -777,8 +777,8 @@ hg_return_t margo_destroy(hg_handle_t handle)
     /* remove the margo_handle_data associated with the handle */
     struct margo_handle_data* handle_data = HG_Get_data(handle);
     if (handle_data) {
-        if (handle_data->free_user_data) {
-            handle_data->free_user_data(handle_data->user_data);
+        if (handle_data->user_free_callback) {
+            handle_data->user_free_callback(handle_data->user_data);
         }
         free(handle_data);
         HG_Set_data(handle, NULL, NULL);
@@ -1882,8 +1882,8 @@ static void margo_handle_data_free(void* args)
      */
     struct margo_handle_data* handle_data = (struct margo_handle_data*)args;
     if (!handle_data) return;
-    if (handle_data->free_user_data)
-        handle_data->free_user_data(handle_data->user_data);
+    if (handle_data->user_free_callback)
+        handle_data->user_free_callback(handle_data->user_data);
     free(handle_data);
 }
 

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -886,8 +886,7 @@ static hg_return_t margo_provider_iforward_internal(
         if (ret != HG_SUCCESS) return (ret);
 
         /* register new ID that includes provider id */
-        ret = margo_register_internal(margo_hg_info_get_instance(hgi), id,
-                                      in_cb, out_cb, _handler_for_NULL,
+        ret = margo_register_internal(mid, id, in_cb, out_cb, _handler_for_NULL,
                                       ABT_POOL_NULL);
         if (ret == 0) return (HG_OTHER_ERROR);
         ret = HG_Registered_disable_response(hgi->hg_class, id,
@@ -1865,6 +1864,12 @@ void __margo_internal_post_wrapper_hooks(margo_instance_id mid)
 {
     __margo_internal_decr_pending(mid);
     if (__margo_internal_finalize_requested(mid)) { margo_finalize(mid); }
+}
+
+hg_return_t __margo_internal_set_handle_data(hg_handle_t handle)
+{
+    // TODO
+    return HG_SUCCESS;
 }
 
 char* margo_get_config(margo_instance_id mid)

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1897,6 +1897,9 @@ hg_return_t __margo_internal_set_handle_data(hg_handle_t handle)
     if (!rpc_data) return HG_OTHER_ERROR;
     struct margo_handle_data* handle_data = calloc(1, sizeof(*handle_data));
     handle_data->mid                      = rpc_data->mid;
+    handle_data->pool                     = rpc_data->pool;
+    handle_data->in_proc_cb               = rpc_data->in_proc_cb;
+    handle_data->out_proc_cb              = rpc_data->out_proc_cb;
     return HG_Set_data(handle, handle_data, margo_handle_data_free);
 }
 

--- a/src/margo-diag.c
+++ b/src/margo-diag.c
@@ -197,13 +197,12 @@ void __margo_breadcrumb_measure(margo_instance_id     mid,
     }
 
     /* Argobots pool info */
-    size_t                 s, s1;
-    struct margo_rpc_data* margo_data;
+    size_t                    s, s1;
+    struct margo_handle_data* margo_data;
     if (type) {
         const struct hg_info* info;
         info       = HG_Get_info(h);
-        margo_data = (struct margo_rpc_data*)HG_Registered_data(mid->hg_class,
-                                                                info->id);
+        margo_data = (struct margo_handle_data*)HG_Get_data(h);
         if (margo_data && margo_data->pool != ABT_POOL_NULL) {
             ABT_pool_get_total_size(margo_data->pool, &s);
             ABT_pool_get_size(margo_data->pool, &s1);

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -194,7 +194,7 @@ struct margo_rpc_data {
 struct margo_handle_data {
     margo_instance_id mid;
     void*             user_data;
-    void (*free_user_data)(void*);
+    void (*user_free_callback)(void*);
 };
 
 struct lookup_cb_evt {

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -193,6 +193,9 @@ struct margo_rpc_data {
 // Data associated with a handle with HG_Set_data
 struct margo_handle_data {
     margo_instance_id mid;
+    ABT_pool          pool;
+    hg_proc_cb_t      in_proc_cb;  /* user-provided input proc */
+    hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
     void*             user_data;
     void (*user_free_callback)(void*);
 };

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -180,6 +180,7 @@ struct margo_request_struct {
     margo_request_type type;
 };
 
+// Data registered to an RPC id with HG_Register_data
 struct margo_rpc_data {
     margo_instance_id mid;
     ABT_pool          pool;
@@ -187,6 +188,13 @@ struct margo_rpc_data {
     hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
     void*             user_data;
     void (*user_free_callback)(void*);
+};
+
+// Data associated with a handle with HG_Set_data
+struct margo_handle_data {
+    margo_instance_id mid;
+    void*             user_data;
+    void (*free_user_data)(void*);
 };
 
 struct lookup_cb_evt {

--- a/tests/my-rpc.c
+++ b/tests/my-rpc.c
@@ -46,10 +46,8 @@ static void my_rpc_ult(hg_handle_t handle)
     buffer = calloc(1, 512);
     assert(buffer);
 
-    /* get handle info and margo instance */
-    hgi = margo_get_info(handle);
-    assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    /* get margo instance */
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     if (in.dump_state) margo_state_dump(mid, "-", 0, NULL);
@@ -133,10 +131,8 @@ static void my_rpc_hang_ult(hg_handle_t handle)
            in.input_val);
     out.ret = 0;
 
-    /* get handle info and margo instance */
-    hgi = margo_get_info(handle);
-    assert(hgi);
-    mid = margo_hg_info_get_instance(hgi);
+    /* get margo instance */
+    mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 
     /* sleep for an hour (to allow client to test timeout capability) */

--- a/tests/my-rpc.c
+++ b/tests/my-rpc.c
@@ -47,6 +47,7 @@ static void my_rpc_ult(hg_handle_t handle)
     assert(buffer);
 
     /* get margo instance */
+    hgi = margo_get_info(handle);
     mid = margo_hg_handle_get_instance(handle);
     assert(mid != MARGO_INSTANCE_NULL);
 

--- a/tests/unit-tests/margo-comm-finalize.c
+++ b/tests/unit-tests/margo-comm-finalize.c
@@ -35,11 +35,11 @@ static void test_rpc_ult(hg_handle_t handle)
     if(in.dereg_flag) {
         hret = margo_deregister(mid, test_rpc_id);
         /* munit_assert_int(hret, ==, HG_SUCCESS); */
+    } else {
+        // it is undefined behavior to call margo_respond
+        // after the RPC has been deregistered
+        hret = margo_respond(handle, NULL);
     }
-
-    hret = margo_respond(handle, NULL);
-    if(hret != HG_SUCCESS)
-        fprintf(stderr, "margo_respond() failure (expected).\n");
 
     margo_destroy(handle);
 


### PR DESCRIPTION
There are many placed in margo where `HG_Registered_data` must be used to retrieve information about an RPC. This includes at least when creating an `hg_handle_t`, when forwarding it, when responding, when getting and freeing input and output, and whenever getting the margo instance from a handle. `HG_Registered_data` takes the RPC id as argument, hence incurring a hash lookup in Mercury.

This PR replaces the use of `HG_Registered_data` with the use of `HG_Get_data`, which works on data associated with a handle rather than data associated with the RPC. The RPC data is copied into the handle's data when the handle is created (whether in `margo_create` or in the handler macro on servers), then all the calls to `HG_Registered_data` can be replaced with calls to `HG_Get_data`, removing hash lookups.

Notes:
- `margo_hg_info_get_instance` is marked as deprecated since it's a bad way (i.e. involving hash lookup) of getting a margo instance from a handle. The warning message indicates that the user should use `margo_hg_handle_get_instance` instead.
- I initially thought about having the handle data simply be a pointer to the corresponding RPC data, to avoid an allocation, with reference counting in the latter to know how many handles need that data. However this solution forces to add a lock around the reference count and prevents user-attached data. I opted for copying the RPC data into the handle data as there is not much data to copy anyway.
- The `margo_handle_data` attached to a handle benefits from the same caching as handles: in `margo_destroy` the user-provided callback is called to free the user-provided data, but the `margo_handle_data` structured is not freed until `HG_Destroy` is called, which means that if the handle makes its way into the handle cache, the `margo_handle_data` structure will remain allocated and will be reused as well the next time the handle is pulled out of the cache.