### PR TITLE
Changes the default provider id (used by clients) from 0 to 0xFFFF

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -70,9 +70,16 @@ typedef void (*margo_finalize_callback_t)(void*);
 #define MARGO_SERVER_MODE 1
 
 /**
- * Default provider id.
+ * Default provider id. This is the provider id used by default
+ * in MARGO_REGISTER, margo_forward, and its variants that do not
+ * ask for a provider id.
+ *
+ * Important: it is not recommended for users to use this provider id
+ * for actual providers. If you work with actual providers, use
+ * provider ids starting from 0. This default provider id is
+ * meant for clients and for RPC not associated with providers.
  */
-#define MARGO_DEFAULT_PROVIDER_ID 0
+#define MARGO_DEFAULT_PROVIDER_ID 0xFFFF
 
 /**
  * Maximum allowed value for a provider id.

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -57,6 +57,8 @@ static inline void demux_id(hg_id_t in, hg_id_t* base_id, uint16_t* provider_id)
     /* clear low order bits */
     *base_id = (in >> (__MARGO_PROVIDER_ID_SIZE * 8))
             << (__MARGO_PROVIDER_ID_SIZE * 8);
+    /* set them to 1s */
+    *base_id |= MARGO_MAX_PROVIDER_ID;
 
     return;
 }


### PR DESCRIPTION
This PR is a solution to the scenario where a user registers a provider with id 0 and another one with id 1, then creates a client, then destroys the provider with id 0. In this situation right now the client will no longer be able to communicate with the provider 1 because the destruction of provider 0 will have deregistered its RPCs.

This PR "solves" this by making the default provider id (used to register clients) 0xFFFF (the max for a uint16_t) instead of 0, modifying the mux/demux functions accordingly. Technically it doesn't solve the problem since someone could still register a provider with id 0xFFFF, then a client, then destroy the provider, and that would leave the client unable to use its RPCs as well. But it's less likely that a user will register a provider with id 0xFFFF, and a comment above MARGO_DEFAULT_PROVIDER_ID makes it clear that they should not use it for providers (I find this solution better than documenting that 0 should not be used as a provider id).