### PR TITLE
Embed breadcrumb in serialization header rather than using extra input buffer

### DIFF
--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -304,14 +304,6 @@ margo_instance_id margo_init_ext(const char*                   address,
     else
         rpc_pool = pools[rpc_pool_index].pool;
 
-    // set input offset to include breadcrumb information in Mercury requests
-    MARGO_TRACE(0, "Setting input offset in hg_class as %d", sizeof(uint64_t));
-    hret = HG_Class_set_input_offset(hg_class, sizeof(uint64_t));
-    if (hret != HG_SUCCESS) {
-        MARGO_ERROR(0, "Could not set input offset in hg_class");
-        goto error;
-    }
-
     // allocate margo instance
     MARGO_TRACE(0, "Allocating margo instance");
     mid = calloc(1, sizeof(*mid));
@@ -1564,7 +1556,7 @@ static void confirm_argobots_configuration(struct json_object* config)
     /* retrieve expected values according to Margo configuration */
     struct json_object* argobots = json_object_object_get(config, "argobots");
     int                 abt_thread_stacksize = json_object_get_int64(
-                        json_object_object_get(argobots, "abt_thread_stacksize"));
+        json_object_object_get(argobots, "abt_thread_stacksize"));
 
     /* NOTE: we skip checking num_stacks; this cannot be retrieved with
      * ABT_info_query_config(). Fortunately it also is not as crucial as the


### PR DESCRIPTION
@carns I'm throwing another PR your way.

This one changes the way the breadcrumb is added to the input buffer. Previously this was done by telling Mercury that 8 bytes of the input buffer should be reserved, and getting direct access to the buffer.

Now this is done via the serialization mechanism (the same mechanism that allows us to have an `hg_return_t` value in a header of a response to propagate an error code back to the client).

This new way of handling the breadcrumb doesn't bring any advantage over the previous way, in terms of performance. It's simply more consistent with the use of the serialization mechanism (now we don't have extra buffer reserved + custom serialization with a potentially custom header). It also paves the way for more fine-grain tracking/profiling.