### PR TITLE
margo_rpc_get_name and margo_handle_get_name

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -907,6 +907,31 @@ hg_return_t margo_get_output(hg_handle_t handle, void* out_struct);
 hg_return_t margo_free_output(hg_handle_t handle, void* out_struct);
 
 /**
+ * @brief Get the name with which an RPC id was registered
+ * (NULL if the RPC id is invalid or wasn't registered with a name).
+ *
+ * @param [in] mid Margo instance
+ * @param [in] rpc_id RPC id
+ *
+ * @return Registered name of the RPC.
+ */
+const char* margo_rpc_get_name(margo_instance_id mid, hg_id_t rpc_id);
+
+/**
+ * @brief Get the name of the RPC corresponding to this handle
+ * (NULL if the handle is invalid or the RPC wasn't registered with a name).
+ *
+ * Note: this function is more efficient than margo_rpc_get_name if you
+ * have a handle at hand, as opposed to calling margo_get_info to get the
+ * RPC id followed by margo_rpc_get_name to get the name from the id.
+ *
+ * @param [in] handle Handle.
+ *
+ * @return Registered name of the RPC.
+ */
+const char* margo_handle_get_name(hg_handle_t handle);
+
+/**
  * @brief Forward an RPC request to a remote provider.
  *
  * @param [in] provider_id Provider ID (may be MARGO_DEFAULT_PROVIDER_ID).

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -184,6 +184,7 @@ struct margo_request_struct {
 struct margo_rpc_data {
     margo_instance_id mid;
     ABT_pool          pool;
+    char*             rpc_name;
     hg_proc_cb_t      in_proc_cb;  /* user-provided input proc */
     hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
     void*             user_data;
@@ -194,9 +195,11 @@ struct margo_rpc_data {
 struct margo_handle_data {
     margo_instance_id mid;
     ABT_pool          pool;
-    hg_proc_cb_t      in_proc_cb;  /* user-provided input proc */
-    hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
-    void*             user_data;
+    const char*       rpc_name; /* note: same pointer as in margo_rpc_data,
+                                   not the responsibility of the handle to free it */
+    hg_proc_cb_t in_proc_cb;    /* user-provided input proc */
+    hg_proc_cb_t out_proc_cb;   /* user-provided output proc */
+    void*        user_data;
     void (*user_free_callback)(void*);
 };
 

--- a/tests/unit-tests/margo-forward.c
+++ b/tests/unit-tests/margo-forward.c
@@ -123,7 +123,7 @@ static MunitResult test_get_name(const MunitParameter params[],
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0,0,0,0,0};
+    hg_return_t hret[6] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 
@@ -226,7 +226,7 @@ static MunitResult test_forward_to_null(const MunitParameter params[],
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0,0,0,0,0};
+    hg_return_t hret[5] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 
@@ -265,7 +265,7 @@ static MunitResult test_self_forward_to_null(const MunitParameter params[],
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0,0,0,0,0};
+    hg_return_t hret[5] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 
@@ -303,7 +303,7 @@ static MunitResult test_forward_invalid(const MunitParameter params[],
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0, 0, 0, 0, 0};
+    hg_return_t hret[5] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 
@@ -341,7 +341,7 @@ static MunitResult test_provider_forward(const MunitParameter params[],
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0,0,0,0,0};
+    hg_return_t hret[5] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 
@@ -380,7 +380,7 @@ static MunitResult test_provider_forward_invalid(const MunitParameter params[],
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0,0,0,0,0};
+    hg_return_t hret[5] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 
@@ -418,7 +418,7 @@ static MunitResult test_self_provider_forward_invalid(const MunitParameter param
 {
     (void)params;
     (void)data;
-    hg_return_t hret[5] = {0,0,0,0,0};
+    hg_return_t hret[5] = {0};
     hg_handle_t handle = HG_HANDLE_NULL;
     hg_addr_t   addr = HG_ADDR_NULL;
 

--- a/tests/unit-tests/munit/munit-goto.h
+++ b/tests/unit-tests/munit/munit-goto.h
@@ -120,7 +120,7 @@ extern "C" {
   MUNIT_POP_DISABLE_MSVC_C4127_
 
 #include <string.h>
-#define munit_assert_string_equa_gotol(a, b, label) \
+#define munit_assert_string_equal_goto(a, b, label) \
   do { \
     const char* munit_tmp_a_ = a; \
     const char* munit_tmp_b_ = b; \


### PR DESCRIPTION
This simple PR adds the two functions listed in the title, to retrieve the name provided when the RPC was registered, respectively from an `hg_id_t` and from an `hg_handle_t`.

There is a unit test that goes with it (in margo-forward.c).

I used these functions in the macros in margo.h to provide the correct RPC name to logging functions. Previously, these macros were using `#__name`, which is the name of the C function, not the name under which the RPC is registered. This was problematic for any thallium- or pymargo-based library since these libraries register a single, generic C callback that then dispatch to the actual RPC function (so the trace would show things like "Calling RPC generic_thallium_rpc" instead of "Calling the_name_the_user_registered_with").

More generally, these functions can be useful in future profiling work.