### PR TITLE
added margo_finalize_and_wait function and unit test for it

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -327,7 +327,16 @@ margo_instance_id margo_init_pool(ABT_pool      progress_pool,
     DEPRECATED("use margo_init_ext instead");
 
 /**
- * @brief Shuts down margo library and its underlying abt and mercury resources.
+ * @brief Requests the margo instance to shut down and free its resources.
+ *
+ * @note This function does not guarantee that the margo instance will be
+ * finalized immediately. When called in a server, where RPCs may be
+ * executing, for example, this call will only margo the margo instance
+ * as finalizing, preventing further RPCs from being scheduled, however
+ * the margo instance will effectively be destroyed only when all the
+ * RPCs have completed.
+ *
+ * @note This function is safe to use within an RPC handler.
  *
  * @param [in] mid Margo instance.
  */
@@ -335,7 +344,7 @@ void margo_finalize(margo_instance_id mid);
 
 /**
  * @brief Suspends the caller until some other entity (e.g. an RPC, thread, or
- * signal handler) invokes margo_finalize().
+ * signal handler) invokes margo_finalize() or margo_finalize_and_wait().
  *
  * @param [in] mid Margo instance.
  *
@@ -344,6 +353,19 @@ void margo_finalize(margo_instance_id mid);
  * progress engine.
  */
 void margo_wait_for_finalize(margo_instance_id mid);
+
+/**
+ * @brief Requests the margo instance to shut down and free its
+ * resources, and wait until it actually does.
+ *
+ * Contrary to margo_finalize(), this function guarantees that
+ * the margo instance has been freed upon returning.
+ *
+ * @note This function should not be called from within an RPC handler.
+ *
+ * @param [in] mid Margo instance.
+ */
+void margo_finalize_and_wait(margo_instance_id mid);
 
 /**
  * @brief Checks whether a Margo instance we initialized is a server

--- a/tests/unit-tests/margo-init.c
+++ b/tests/unit-tests/margo-init.c
@@ -89,6 +89,8 @@ static MunitResult finalize_and_wait(const MunitParameter params[], void* data)
 
     struct test_context* ctx = (struct test_context*)data;
 
+    ABT_init(0, NULL);
+
     /* init and finalize_and_wait */
     ctx->mid = margo_init(protocol, MARGO_SERVER_MODE,
                           use_progress_thread, rpc_thread_count);
@@ -113,7 +115,12 @@ static MunitResult finalize_and_wait(const MunitParameter params[], void* data)
     margo_forward(handle, NULL);
     margo_destroy(handle);
 
+    double t1 = ABT_get_wtime();
     margo_finalize_and_wait(ctx->mid);
+    double t2 = ABT_get_wtime();
+    munit_assert_double(t2-t1, >=, 0.5);
+
+    ABT_finalize();
 
     return MUNIT_OK;
 }

--- a/tests/unit-tests/margo-init.c
+++ b/tests/unit-tests/margo-init.c
@@ -71,6 +71,53 @@ static MunitResult init_cycle_client(const MunitParameter params[], void* data)
     return MUNIT_OK;
 }
 
+DECLARE_MARGO_RPC_HANDLER(rpc_ult)
+static void rpc_ult(hg_handle_t handle)
+{
+    margo_instance_id mid = margo_hg_handle_get_instance(handle);
+    margo_thread_sleep(mid, 1000.0);
+    margo_destroy(handle);
+    return;
+}
+DEFINE_MARGO_RPC_HANDLER(rpc_ult)
+
+static MunitResult finalize_and_wait(const MunitParameter params[], void* data)
+{
+    const char* protocol = munit_parameters_get(params, "protocol");
+    int use_progress_thread = atoi(munit_parameters_get(params, "use_progress_thread"));
+    int rpc_thread_count = atoi(munit_parameters_get(params, "rpc_thread_count"));
+
+    struct test_context* ctx = (struct test_context*)data;
+
+    /* init and finalize_and_wait */
+    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE,
+                          use_progress_thread, rpc_thread_count);
+    munit_assert_not_null(ctx->mid);
+
+    margo_finalize_and_wait(ctx->mid);
+
+    /* init and finalize_and_wait but issue a slow RPC first */
+    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE,
+                          use_progress_thread, rpc_thread_count);
+    munit_assert_not_null(ctx->mid);
+
+    hg_id_t rpc_id = MARGO_REGISTER(ctx->mid, "rpc", void, void, rpc_ult);
+    margo_registered_disable_response(ctx->mid, rpc_id, HG_TRUE);
+
+    hg_handle_t handle = HG_HANDLE_NULL;
+    hg_addr_t addr = HG_ADDR_NULL;
+
+    margo_addr_self(ctx->mid, &addr);
+    margo_create(ctx->mid, addr, rpc_id, &handle);
+    margo_addr_free(ctx->mid, addr);
+    margo_forward(handle, NULL);
+    margo_destroy(handle);
+
+    margo_finalize_and_wait(ctx->mid);
+
+    return MUNIT_OK;
+}
+
 static char* protocol_params[] = {
     "na+sm", NULL
 };
@@ -93,6 +140,7 @@ static MunitParameterEnum test_params[] = {
 static MunitTest tests[] = {
     { "/init-cycle-client", init_cycle_client, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
     { "/init-cycle-server", init_cycle_server, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    { "/finalize-and-wait", finalize_and_wait, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
     { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };
 


### PR DESCRIPTION
This PR adds the `margo_finalize_and_wait` function.

Contrary to `margo_finalize`, which only "requests" the margo instance to be finalized (something that may actually be done by, e.g., the last pending RPC), `margo_finalize_and_wait` actually blocks until the margo instance is cleaned up and has finalized.

Contrary to `margo_wait_for_finalize`, `margo_finalize_and_wait` requests that the instance finalizes.

The unit test tests the scenario of just initializing and finalizing a margo instance, in which case `margo_finalize_and_wait` will be the function that actually calls finalize. It also tests a scenario in which an RPC is received that takes 1 second to complete. Because the RPC is pending, `margo_finalize_and_wait` will block until the RPC completes. This is checked by looking at the time it takes to complete.