### PR TITLE
improve margo-info address handling

### DIFF
--- a/src/margo-info.c
+++ b/src/margo-info.c
@@ -288,10 +288,16 @@ int main(int argc, char** argv)
         "# - This utility queries software stack capability, not hardware "
         "availability.\n");
     printf(
-        "# - UCX does not directly expose which underlying transport plugins "
-        "are available.\n   The \"dc\" protocol type is only available for "
-        "Mellanox InfiniBand adapters, however.\n   See \"ucx_info -d\" for "
-        "more information about transportws available in the UCX library.\n");
+        "# - UCX does not directly expose which underlying network plugins "
+        "are\n"
+        "#   available. The \"dc\" protocol type is only supported on "
+        "Mellanox\n"
+        "#   InfiniBand adapters, however. See \"ucx_info -d\" for more "
+        "information \n"
+        "#   about transports available in your UCX library.\n");
+    printf(
+        "# - UCX will automatically choose a transport if you select the\n"
+        "#   \"ucx+all://\" address string.\n");
     printf(
         "# - For more information about a particular address specifier, "
         "please\n");

--- a/src/margo-info.c
+++ b/src/margo-info.c
@@ -62,9 +62,13 @@ struct options {
     X("psm2+psm2://", "psm2", "psm2", "integrated PSM2 plugin (OmniPath)")     \
     X("na+sm://", "na", "sm", "integrated sm plugin (shared memory)")          \
     X("bmi+tcp://", "bmi", "tcp", "BMI tcp module (TCP/IP)")                   \
-    X("ucx+tcp://", "ucx", "tcp", "UCX TCP/IP")                                \
-    X("ucx+verbs://", "ucx", "verbs", "UCX Verbs")                             \
-    X("ucx+all://", "ucx", "<any>", "UCX automatic transport")                 \
+    X("ucx+tcp://", "ucx", "tcp", "UCX TCP/IP over SOCK_STREAM sockets")       \
+    X("ucx+rc://", "ucx", "rc", "UCX RC (reliable connection)")                \
+    X("ucx+ud://", "ucx", "ud", "UCX UD (unreliable datagram)")                \
+    X("ucx+dc://", "ucx", "dc",                                                \
+      "UCX DC (dynamic connection, only available on Mellanox adapters)")      \
+    X("ucx+all://", "ucx", "<any>",                                            \
+      "UCX default/automatic transport selection")                             \
     X("tcp://", "<any>", "tcp", "TCP/IP protocol, transport not specified")    \
     X("verbs://", "<any>", "verbs", "Verbs protocol, transport not specified") \
     X("sm://", "<any>", "sm",                                                  \
@@ -259,6 +263,11 @@ int main(int argc, char** argv)
     printf(
         "# - This utility queries software stack capability, not hardware "
         "availability.\n");
+    printf(
+        "# - UCX does not directly expose which underlying transport plugins "
+        "are available.\n   The \"dc\" protocol type is only available for "
+        "Mellanox InfiniBand adapters, however.\n   See \"ucx_info -d\" for "
+        "more information about transportws available in the UCX library.\n");
     printf(
         "# - For more information about a particular address specifier, "
         "please\n");


### PR DESCRIPTION
Fixes #217 

- replace invalid ucx+verbs address string with ucx+rc, ucx+dc, and ucx+ud
- add more guidance in output on meaning of ucx address strings
- allow query of address strings that are unknown to the margo-info utility