### PR TITLE
Functions to add and remove pools and xstreams

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,15 +147,9 @@ AC_MSG_RESULT(no)
 )
 
 # check if this version of Argobots supports ABT_pool_pop_threads
-AC_MSG_CHECKING(for ABT_pool_pop_threads in Argobots)
-AC_TRY_COMPILE([
-#include <abt.h>
-], [
-ABT_pool_pop_threads(ABT_POOL_NULL, NULL, 0, NULL);
-],
-AC_MSG_RESULT(yes)
+AC_CHECK_FUNC(ABT_pool_pop_threads,
 AC_DEFINE(HAVE_ABT_POOL_POP_THREADS, 1, [can use ABT_pool_pop_threads]),
-AC_MSG_RESULT(no)
+[]
 )
 
 # check if dl_iterate_phdr() is available

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,18 @@ AC_DEFINE(HAVE_ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC, 1, [can query lazy 
 AC_MSG_RESULT(no)
 )
 
+# check if this version of Argobots supports ABT_pool_pop_threads
+AC_MSG_CHECKING(for ABT_pool_pop_threads in Argobots)
+AC_TRY_COMPILE([
+#include <abt.h>
+], [
+ABT_pool_pop_threads(ABT_POOL_NULL, NULL, 0, NULL);
+],
+AC_MSG_RESULT(yes)
+AC_DEFINE(HAVE_ABT_POOL_POP_THREADS, 1, [can use ABT_pool_pop_threads]),
+AC_MSG_RESULT(no)
+)
+
 # check if dl_iterate_phdr() is available
 AC_MSG_CHECKING(for dl_iterate_phdr)
 AC_TRY_LINK([

--- a/include/margo-config.h
+++ b/include/margo-config.h
@@ -143,6 +143,7 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
  * @param [in] mid Margo instance.
  * @param [in] name Name to give the pool (auto-generated if NULL).
  * @param [in] pool Pool handle.
+ * @param [in] take_ownership Give ownership to the Margo instance.
  * @param [out] info Resulting pool information.
  *
  * @return HG_SUCCESS or other HG error code.
@@ -150,6 +151,7 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
 hg_return_t margo_add_pool_external(margo_instance_id       mid,
                                     const char*             name,
                                     ABT_pool                pool,
+                                    ABT_bool                take_ownership,
                                     struct margo_pool_info* info);
 
 /**
@@ -233,13 +235,15 @@ hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
  * @param [in] mid Margo instance.
  * @param [in] name Name to give the xstream (auto-generated if NULL).
  * @param [in] xstream ES handle.
+ * @param [in] take_ownership Give ownership to the Margo instance.
  * @param [out] info Resulting xstream information.
  *
  * @return HG_SUCCESS or other HG error code.
  */
-hg_return_t margo_add_xstream_external(margo_instance_id          mid,
-                                       const char*                name,
-                                       ABT_xstream                xstream,
+hg_return_t margo_add_xstream_external(margo_instance_id mid,
+                                       const char*       name,
+                                       ABT_xstream       xstream,
+                                       ABT_bool          take_ownership,
                                        struct margo_xstream_info* info);
 
 /**

--- a/include/margo-config.h
+++ b/include/margo-config.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+#include <mercury.h>
 #include <abt.h>
 
 #define DEPRECATED(msg) __attribute__((deprecated(msg)))
@@ -117,6 +118,41 @@ hg_return_t margo_find_pool_by_index(margo_instance_id       mid,
                                      struct margo_pool_info* info);
 
 /**
+ * @brief Creates a new Argobots pool according to the provided
+ * JSON description (following the same format as the pool objects
+ * in the Margo configuration) and fill the output margo_pool_info
+ * structure.
+ *
+ * @param [in] mid Margo instance.
+ * @param [in] json JSON-formatted description.
+ * @param [out] info Resulting pool information.
+ *
+ * @return HG_SUCCESS or other HG error code (e.g. HG_INVALID_ARG).
+ */
+hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
+                                     const char*             json,
+                                     struct margo_pool_info* info);
+
+/**
+ * @brief Adds an existing Argobots pool for Margo to use.
+ *
+ * Important: it is the user's responsibility to ensure that the ABT_pool
+ * remains valid until the Margo instance is destroyed or until the
+ * pool is removed from the Margo instance.
+ *
+ * @param [in] mid Margo instance.
+ * @param [in] name Name to give the pool (auto-generated if NULL).
+ * @param [in] pool Pool handle.
+ * @param [out] info Resulting pool information.
+ *
+ * @return HG_SUCCESS or other HG error code.
+ */
+hg_return_t margo_add_pool_external(margo_instance_id       mid,
+                                    const char*             name,
+                                    ABT_pool                pool,
+                                    struct margo_pool_info* info);
+
+/**
  * @brief Structure used to retrieve information about margo-managed xstreams.
  */
 struct margo_xstream_info {
@@ -166,6 +202,45 @@ hg_return_t margo_find_xstream_by_name(margo_instance_id          mid,
 hg_return_t margo_find_xstream_by_index(margo_instance_id          mid,
                                         uint32_t                   index,
                                         struct margo_xstream_info* info);
+
+/**
+ * @brief Creates a new Argobots xstream according to the provided
+ * JSON description (following the same format as the xstream objects
+ * in the Margo configuration) and fill the output margo_xstream_info
+ * structure.
+ *
+ * @param [in] mid Margo instance.
+ * @param [in] json JSON-formatted description.
+ * @param [out] info Resulting xstream information.
+ *
+ * @return HG_SUCCESS or other HG error code (e.g. HG_INVALID_ARG).
+ */
+hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
+                                        const char*                json,
+                                        struct margo_xstream_info* info);
+
+/**
+ * @brief Adds an existing Argobots xstream for Margo to use.
+ *
+ * Note: any pool associated with the ES that is not yet registered
+ * with the Margo instance will be added to the instance as an external
+ * pool.
+ *
+ * Important: it is the user's responsibility to ensure that the ABT_xstream
+ * remains valid until the Margo instance is destroyed or until the
+ * xstream is removed from the Margo instance.
+ *
+ * @param [in] mid Margo instance.
+ * @param [in] name Name to give the xstream (auto-generated if NULL).
+ * @param [in] xstream ES handle.
+ * @param [out] info Resulting xstream information.
+ *
+ * @return HG_SUCCESS or other HG error code.
+ */
+hg_return_t margo_add_xstream_external(margo_instance_id          mid,
+                                       const char*                name,
+                                       ABT_xstream                xstream,
+                                       struct margo_xstream_info* info);
 
 /**
  * @brief Get a pool from the configuration.

--- a/include/margo-config.h
+++ b/include/margo-config.h
@@ -334,6 +334,22 @@ hg_return_t margo_remove_xstream_by_handle(margo_instance_id mid,
                                            ABT_xstream       handle);
 
 /**
+ * @brief This helper function transfers the ULT from one pool to another.
+ * It can be used to move ULTs out of a pool that we wish to remove.
+ *
+ * Note: this function will not remove ULTs that are blocked.
+ * The caller can check for any remaining blocked ULTs by calling
+ * ABT_pool_get_total_size(origin_pool, &size).
+ *
+ * @param origin_pool Origin pool.
+ * @param target_pool Target pool.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_transfer_pool_content(ABT_pool origin_pool,
+                                        ABT_pool target_pool);
+
+/**
  * @brief Get a pool from the configuration.
  *
  * @param [in] mid Margo instance.

--- a/include/margo-config.h
+++ b/include/margo-config.h
@@ -155,6 +155,46 @@ hg_return_t margo_add_pool_external(margo_instance_id       mid,
                                     struct margo_pool_info* info);
 
 /**
+ * @brief Removes the pool at the specified index.
+ * If the pool has been created by Margo (in margo_init or
+ * via margo_add_pool_from_json) or if it has been added
+ * via margo_add_pool_external with take_ownership = true,
+ * this function will free the pool. Otherwise, this function
+ * will simply remove it from the pools known to the margo instance.
+ *
+ * This function will fail if the pool is used by an xstream
+ * (that margo knows about), or if the pool is not empty.
+ *
+ * @param mid Margo instance.
+ * @param index Index of the pool.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_remove_pool_by_index(margo_instance_id mid, uint32_t index);
+
+/**
+ * @brief Same as margo_remove_pool_by_index by using the
+ * name of the pool to remove.
+ *
+ * @param mid Margo instance.
+ * @param name Name of the pool to remove.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_remove_pool_by_name(margo_instance_id mid, const char* name);
+
+/**
+ * @brief Same as margo_remove_pool_by_index by using the
+ * name of the pool to remove.
+ *
+ * @param mid Margo instance.
+ * @param name Name of the pool to remove.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_remove_pool_by_handle(margo_instance_id mid, ABT_pool handle);
+
+/**
  * @brief Structure used to retrieve information about margo-managed xstreams.
  */
 struct margo_xstream_info {
@@ -245,6 +285,53 @@ hg_return_t margo_add_xstream_external(margo_instance_id mid,
                                        ABT_xstream       xstream,
                                        ABT_bool          take_ownership,
                                        struct margo_xstream_info* info);
+
+/**
+ * @brief Removes the xstream at the specified index.
+ * If the xstream has been created by Margo (in margo_init or
+ * via margo_add_xstream_from_json) or if it has been added
+ * via margo_add_xstream_external with take_ownership = true,
+ * this function will join the xstream and free it. Otherwise,
+ * this function will simply remove it from the xstreams known
+ * to the margo instance.
+ *
+ * Note: this function will not check whether the removal
+ * will leave pools detached from any xstream. It is the caller's
+ * responsibility to ensure that any work left in the pools
+ * associated with the removed xstream will be picked up by
+ * another xstream now or in the future.
+ *
+ * @param mid Margo instance.
+ * @param index Index of the xstream.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_remove_xstream_by_index(margo_instance_id mid,
+                                          uint32_t          index);
+
+/**
+ * @brief Same as margo_remove_xstream_by_index by using the
+ * name of the xstream to remove.
+ *
+ * @param mid Margo instance.
+ * @param name Name of the xstream to remove.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_remove_xstream_by_name(margo_instance_id mid,
+                                         const char*       name);
+
+/**
+ * @brief Same as margo_remove_xstream_by_index by using the
+ * name of the xstream to remove.
+ *
+ * @param mid Margo instance.
+ * @param name Name of the xstream to remove.
+ *
+ * @return HG_SUCCESS or other error code.
+ */
+hg_return_t margo_remove_xstream_by_handle(margo_instance_id mid,
+                                           ABT_xstream       handle);
 
 /**
  * @brief Get a pool from the configuration.

--- a/src/margo-abt-config.c
+++ b/src/margo-abt-config.c
@@ -1420,12 +1420,14 @@ bool __margo_abt_remove_pool(margo_abt_t* abt, uint32_t index)
                     "Cannot remove pool %s at index %u "
                     "because it is used by %u RPC handlers",
                     pool->name, index, pool->num_rpc_ids);
+        return false;
     }
     if (pool->num_xstreams) {
         margo_error(abt->mid,
                     "Cannot remove pool %s at index %u "
                     "because it is used by %u running xstreams",
                     pool->name, index, pool->num_xstreams);
+        return false;
     }
     __margo_abt_pool_destroy(pool);
     margo_abt_pool_t* last_pool = &(abt->pools[abt->pools_len - 1]);
@@ -1443,6 +1445,10 @@ bool __margo_abt_remove_xstream(margo_abt_t* abt, uint32_t index)
         return false;
     }
     margo_abt_xstream_t* xstream = &(abt->xstreams[index]);
+    if (strcmp(xstream->name, "__primary__") == 0) {
+        margo_error(abt->mid, "Cannot remove primary xstream");
+        return false;
+    }
     __margo_abt_xstream_destroy(xstream, abt);
     margo_abt_xstream_t* last_xstream = &(abt->xstreams[abt->xstreams_len - 1]);
     if (index != abt->xstreams_len - 1)

--- a/src/margo-abt-config.c
+++ b/src/margo-abt-config.c
@@ -341,15 +341,17 @@ bool __margo_abt_sched_init_external(ABT_sched          sched,
                                      const margo_abt_t* abt,
                                      margo_abt_sched_t* s)
 {
-    s->type  = strdup("external");
-    s->sched = sched;
+    s->type      = strdup("external");
+    s->sched     = sched;
+    s->pools     = NULL;
+    s->num_pools = 0;
 
     int num_pools;
     int ret = ABT_sched_get_num_pools(sched, &num_pools);
     if (ret != ABT_SUCCESS) {
         margo_error(0, "ABT_sched_get_num_pools failed with error code %d",
                     ret);
-        return false;
+        goto error;
     }
 
     s->num_pools    = (size_t)num_pools;

--- a/src/margo-abt-config.c
+++ b/src/margo-abt-config.c
@@ -1195,6 +1195,16 @@ void __margo_abt_destroy(margo_abt_t* a)
     }
 }
 
+void __margo_abt_lock(const margo_abt_t* abt)
+{
+    ABT_mutex_lock(ABT_MUTEX_MEMORY_GET_HANDLE(&abt->mtx));
+}
+
+void __margo_abt_unlock(const margo_abt_t* abt)
+{
+    ABT_mutex_unlock(ABT_MUTEX_MEMORY_GET_HANDLE(&abt->mtx));
+}
+
 int __margo_abt_find_pool_by_name(const margo_abt_t* abt, const char* name)
 {
     if (abt == NULL || name == NULL) return -1;

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -78,8 +78,7 @@ bool __margo_abt_pool_init_external(const char*        name,
 
 /* Struct to track scheduler information in a margo_abt_xstream. */
 typedef struct margo_abt_sched {
-    ABT_sched sched;
-    char*     type;
+    char* type;
 } margo_abt_sched_t;
 
 bool __margo_abt_sched_validate_json(const json_object_t* sched,
@@ -88,13 +87,15 @@ bool __margo_abt_sched_validate_json(const json_object_t* sched,
 
 bool __margo_abt_sched_init_from_json(const json_object_t* config,
                                       const margo_abt_t*   abt,
-                                      margo_abt_sched_t*   sched);
+                                      margo_abt_sched_t*   sched,
+                                      ABT_sched*           abt_sched);
 
 bool __margo_abt_sched_init_external(ABT_sched          handle,
                                      const margo_abt_t* abt,
                                      margo_abt_sched_t* sched);
 
 json_object_t* __margo_abt_sched_to_json(const margo_abt_sched_t* sched,
+                                         ABT_sched                abt_sched,
                                          const margo_abt_t*       abt,
                                          int                      options);
 

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -80,8 +80,6 @@ bool __margo_abt_pool_init_external(const char*        name,
 typedef struct margo_abt_sched {
     ABT_sched sched;
     char*     type;
-    uint32_t* pools;
-    size_t    num_pools;
 } margo_abt_sched_t;
 
 bool __margo_abt_sched_validate_json(const json_object_t* sched,

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -173,4 +173,6 @@ bool __margo_abt_add_external_pool(margo_abt_t* abt,
 bool __margo_abt_add_external_xstream(margo_abt_t* abt,
                                       const char*  name,
                                       ABT_xstream  xstream);
+bool __margo_abt_remove_pool(margo_abt_t* abt, uint32_t index);
+bool __margo_abt_remove_xstream(margo_abt_t* abt, uint32_t index);
 #endif

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -54,11 +54,12 @@ typedef struct margo_abt_pool {
     char*          name;
     ABT_pool       pool;
     char*          kind;
-    optional_char* access;      /* Unknown for custom user pools */
-    uint32_t       num_rpc_ids; /* Number of RPC ids that use this pool */
-    bool margo_free_flag;       /* flag if Margo is responsible for freeing */
-    bool used_by_primary;       /* flag indicating the this pool is used by the
-                                   primary ES */
+    optional_char* access;          /* Unknown for custom user pools */
+    _Atomic(uint32_t) num_rpc_ids;  /* Number of RPC ids that use this pool */
+    _Atomic(uint32_t) num_xstreams; /* Number of xstreams that use this pool */
+    bool margo_free_flag; /* flag if Margo is responsible for freeing */
+    bool used_by_primary; /* flag indicating the this pool is used by the
+                             primary ES */
 } margo_abt_pool_t;
 
 bool __margo_abt_pool_validate_json(const json_object_t* config);
@@ -128,7 +129,8 @@ json_object_t* __margo_abt_xstream_to_json(const margo_abt_xstream_t* xstream,
                                            const margo_abt_t*         abt,
                                            int                        options);
 
-void __margo_abt_xstream_destroy(margo_abt_xstream_t* xstream);
+void __margo_abt_xstream_destroy(margo_abt_xstream_t* xstream,
+                                 const margo_abt_t*   abt);
 
 /* Argobots environment */
 typedef struct margo_abt {

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -62,7 +62,8 @@ typedef struct margo_abt_pool {
                              primary ES */
 } margo_abt_pool_t;
 
-bool __margo_abt_pool_validate_json(const json_object_t* config);
+bool __margo_abt_pool_validate_json(const json_object_t* config,
+                                    const margo_abt_t*   abt);
 
 bool __margo_abt_pool_init_from_json(const json_object_t* config,
                                      const margo_abt_t*   abt,
@@ -70,7 +71,7 @@ bool __margo_abt_pool_init_from_json(const json_object_t* config,
 
 json_object_t* __margo_abt_pool_to_json(const margo_abt_pool_t* pool);
 
-void __margo_abt_pool_destroy(margo_abt_pool_t* pool);
+void __margo_abt_pool_destroy(margo_abt_pool_t* pool, const margo_abt_t* abt);
 
 bool __margo_abt_pool_init_external(const char*        name,
                                     ABT_pool           handle,

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -150,6 +150,12 @@ typedef struct margo_abt {
     char* profiling_dir;
 } margo_abt_t;
 
+// Note: none of the functions bellow lock/unlock their access
+// to the margo_abt_t structure. It is up to the public functions
+// in margo-config.c to do so.
+void __margo_abt_lock(const margo_abt_t* abt);
+void __margo_abt_unlock(const margo_abt_t* abt);
+
 bool __margo_abt_validate_json(const json_object_t* config);
 
 bool __margo_abt_init_from_json(const json_object_t* config, margo_abt_t*);

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -26,7 +26,9 @@ char* margo_get_config_opt(margo_instance_id mid, int options)
     json_object_object_add_ex(root, "version",
                               json_object_new_string(PACKAGE_VERSION), flags);
     // argobots section
+    __margo_abt_lock(&mid->abt);
     struct json_object* abt_json = __margo_abt_to_json(&(mid->abt), options);
+    __margo_abt_unlock(&mid->abt);
     json_object_object_add_ex(root, "argobots", abt_json, flags);
     // mercury section
     struct json_object* hg_json = __margo_hg_to_json(&(mid->hg));
@@ -79,11 +81,20 @@ char* margo_get_config_opt(margo_instance_id mid, int options)
     return (char*)content;
 }
 
-size_t margo_get_num_pools(margo_instance_id mid) { return mid->abt.pools_len; }
+size_t margo_get_num_pools(margo_instance_id mid)
+{
+    __margo_abt_lock(&mid->abt);
+    size_t ret = mid->abt.pools_len;
+    __margo_abt_unlock(&mid->abt);
+    return ret;
+}
 
 size_t margo_get_num_xstreams(margo_instance_id mid)
 {
-    return mid->abt.xstreams_len;
+    __margo_abt_lock(&mid->abt);
+    size_t ret = mid->abt.xstreams_len;
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_find_pool_by_handle(margo_instance_id       mid,
@@ -92,6 +103,8 @@ hg_return_t margo_find_pool_by_handle(margo_instance_id       mid,
 {
     if (mid == MARGO_INSTANCE_NULL || handle == ABT_POOL_NULL)
         return HG_INVALID_ARG;
+    hg_return_t ret = HG_NOENTRY;
+    __margo_abt_lock(&mid->abt);
     for (uint32_t i = 0; i < mid->abt.pools_len; ++i) {
         if (mid->abt.pools[i].pool == handle) {
             if (info) {
@@ -99,10 +112,12 @@ hg_return_t margo_find_pool_by_handle(margo_instance_id       mid,
                 info->name  = mid->abt.pools[i].name;
                 info->pool  = mid->abt.pools[i].pool;
             }
-            return HG_SUCCESS;
+            ret = HG_SUCCESS;
+            break;
         }
     }
-    return HG_NOENTRY;
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_find_pool_by_name(margo_instance_id       mid,
@@ -110,6 +125,8 @@ hg_return_t margo_find_pool_by_name(margo_instance_id       mid,
                                     struct margo_pool_info* info)
 {
     if (mid == MARGO_INSTANCE_NULL || name == NULL) return HG_INVALID_ARG;
+    hg_return_t ret = HG_NOENTRY;
+    __margo_abt_lock(&mid->abt);
     for (uint32_t i = 0; i < mid->abt.pools_len; ++i) {
         if (mid->abt.pools[i].name == NULL) continue;
         if (strcmp(mid->abt.pools[i].name, name) == 0) {
@@ -118,23 +135,30 @@ hg_return_t margo_find_pool_by_name(margo_instance_id       mid,
                 info->name  = mid->abt.pools[i].name;
                 info->pool  = mid->abt.pools[i].pool;
             }
-            return HG_SUCCESS;
+            ret = HG_SUCCESS;
+            break;
         }
     }
-    return HG_NOENTRY;
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_find_pool_by_index(margo_instance_id       mid,
                                      uint32_t                index,
                                      struct margo_pool_info* info)
 {
-    if (mid == MARGO_INSTANCE_NULL || index >= mid->abt.pools_len)
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
+    if (index >= mid->abt.pools_len) {
+        __margo_abt_unlock(&mid->abt);
         return HG_INVALID_ARG;
+    }
     if (info) {
         info->index = index;
         info->name  = mid->abt.pools[index].name;
         info->pool  = mid->abt.pools[index].pool;
     }
+    __margo_abt_unlock(&mid->abt);
     return HG_SUCCESS;
 }
 
@@ -144,6 +168,7 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
 {
     struct json_object*     json    = NULL;
     struct json_tokener*    tokener = json_tokener_new();
+    hg_return_t             ret     = HG_SUCCESS;
     enum json_tokener_error jerr;
     if (json_str && json_str[0]) {
         json = json_tokener_parse_ex(tokener, json_str, strlen(json_str));
@@ -156,6 +181,7 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
         }
     }
     json_tokener_free(tokener);
+    __margo_abt_lock(&mid->abt);
     bool b = __margo_abt_add_pool_from_json(&mid->abt, json);
     json_object_put(json);
     if (b) {
@@ -164,10 +190,11 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
             info->name  = mid->abt.pools[info->index].name;
             info->pool  = mid->abt.pools[info->index].pool;
         }
-        return HG_SUCCESS;
     } else {
-        return HG_INVALID_ARG;
+        ret = HG_INVALID_ARG;
     }
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_add_pool_external(margo_instance_id       mid,
@@ -177,6 +204,8 @@ hg_return_t margo_add_pool_external(margo_instance_id       mid,
                                     struct margo_pool_info* info)
 {
     if (!mid) return HG_INVALID_ARG;
+    hg_return_t ret = HG_SUCCESS;
+    __margo_abt_lock(&mid->abt);
     bool b = __margo_abt_add_external_pool(&mid->abt, name, pool);
     if (b) {
         mid->abt.pools[mid->abt.pools_len - 1].margo_free_flag = take_ownership;
@@ -185,32 +214,101 @@ hg_return_t margo_add_pool_external(margo_instance_id       mid,
             info->name  = mid->abt.pools[info->index].name;
             info->pool  = mid->abt.pools[info->index].pool;
         }
-        return HG_SUCCESS;
     } else {
-        return HG_INVALID_ARG;
+        ret = HG_INVALID_ARG;
     }
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_remove_pool_by_index(margo_instance_id mid, uint32_t index)
 {
-    bool ret = __margo_abt_remove_pool(&mid->abt, index);
-    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+    if (!mid) return HG_INVALID_ARG;
+    hg_return_t ret = HG_SUCCESS;
+    __margo_abt_lock(&mid->abt);
+    if (index >= mid->abt.pools_len) {
+        ret = HG_INVALID_ARG;
+        goto finish;
+    }
+    if (mid->abt.pools[index].pool == MARGO_PROGRESS_POOL(mid)) {
+        margo_error(mid, "Removing the progress pool is not allowed");
+        ret = HG_OTHER_ERROR;
+        goto finish;
+    }
+    if (mid->abt.pools[index].pool == MARGO_RPC_POOL(mid)) {
+        margo_error(mid, "Removing the default handler pool is not allowed");
+        ret = HG_OTHER_ERROR;
+        goto finish;
+    }
+    bool b = __margo_abt_remove_pool(&mid->abt, index);
+    if (!b) ret = HG_OTHER_ERROR;
+finish:
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_remove_pool_by_name(margo_instance_id mid, const char* name)
 {
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
+    hg_return_t ret = HG_SUCCESS;
+    ;
     int32_t index = __margo_abt_find_pool_by_name(&mid->abt, name);
-    if (index < 0) return HG_INVALID_ARG;
-    bool ret = __margo_abt_remove_pool(&mid->abt, index);
-    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+    if (index < 0) {
+        ret = HG_INVALID_ARG;
+        goto finish;
+    }
+    if (index >= (int32_t)mid->abt.pools_len) {
+        ret = HG_INVALID_ARG;
+        goto finish;
+    }
+    if (mid->abt.pools[index].pool == MARGO_PROGRESS_POOL(mid)) {
+        margo_error(mid, "Removing the progress pool is not allowed");
+        ret = HG_OTHER_ERROR;
+        goto finish;
+    }
+    if (mid->abt.pools[index].pool == MARGO_RPC_POOL(mid)) {
+        margo_error(mid, "Removing the default handler pool is not allowed");
+        ret = HG_OTHER_ERROR;
+        goto finish;
+    }
+    bool b = __margo_abt_remove_pool(&mid->abt, index);
+    if (!b) ret = HG_OTHER_ERROR;
+finish:
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_remove_pool_by_handle(margo_instance_id mid, ABT_pool handle)
 {
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
+    hg_return_t ret = HG_SUCCESS;
+    ;
     int32_t index = __margo_abt_find_pool_by_handle(&mid->abt, handle);
-    if (index < 0) return HG_INVALID_ARG;
-    bool ret = __margo_abt_remove_pool(&mid->abt, index);
-    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+    if (index < 0) {
+        ret = HG_INVALID_ARG;
+        goto finish;
+    }
+    if (index >= (int32_t)mid->abt.pools_len) {
+        ret = HG_INVALID_ARG;
+        goto finish;
+    }
+    if (mid->abt.pools[index].pool == MARGO_PROGRESS_POOL(mid)) {
+        margo_error(mid, "Removing the progress pool is not allowed");
+        ret = HG_OTHER_ERROR;
+        goto finish;
+    }
+    if (mid->abt.pools[index].pool == MARGO_RPC_POOL(mid)) {
+        margo_error(mid, "Removing the default handler pool is not allowed");
+        ret = HG_OTHER_ERROR;
+        goto finish;
+    }
+    bool b = __margo_abt_remove_pool(&mid->abt, index);
+    if (!b) ret = HG_OTHER_ERROR;
+finish:
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_find_xstream_by_handle(margo_instance_id          mid,
@@ -219,6 +317,8 @@ hg_return_t margo_find_xstream_by_handle(margo_instance_id          mid,
 {
     if (mid == MARGO_INSTANCE_NULL || handle == ABT_XSTREAM_NULL)
         return HG_INVALID_ARG;
+    hg_return_t ret = HG_NOENTRY;
+    __margo_abt_lock(&mid->abt);
     for (uint32_t i = 0; i < mid->abt.xstreams_len; ++i) {
         if (mid->abt.xstreams[i].xstream == handle) {
             if (info) {
@@ -226,10 +326,12 @@ hg_return_t margo_find_xstream_by_handle(margo_instance_id          mid,
                 info->xstream = mid->abt.xstreams[i].xstream;
                 info->index   = i;
             }
-            return HG_SUCCESS;
+            ret = HG_SUCCESS;
+            break;
         }
     }
-    return HG_NOENTRY;
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_find_xstream_by_name(margo_instance_id          mid,
@@ -237,6 +339,8 @@ hg_return_t margo_find_xstream_by_name(margo_instance_id          mid,
                                        struct margo_xstream_info* info)
 {
     if (mid == MARGO_INSTANCE_NULL || name == NULL) return HG_INVALID_ARG;
+    hg_return_t ret = HG_NOENTRY;
+    __margo_abt_lock(&mid->abt);
     for (uint32_t i = 0; i < mid->abt.xstreams_len; ++i) {
         if (mid->abt.xstreams[i].name == NULL) continue;
         if (strcmp(mid->abt.xstreams[i].name, name) == 0) {
@@ -245,23 +349,29 @@ hg_return_t margo_find_xstream_by_name(margo_instance_id          mid,
                 info->xstream = mid->abt.xstreams[i].xstream;
                 info->index   = i;
             }
-            return HG_SUCCESS;
+            ret = HG_SUCCESS;
         }
     }
-    return HG_NOENTRY;
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_find_xstream_by_index(margo_instance_id          mid,
                                         uint32_t                   index,
                                         struct margo_xstream_info* info)
 {
-    if (mid == MARGO_INSTANCE_NULL || index >= mid->abt.xstreams_len)
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
+    if (index >= mid->abt.xstreams_len) {
+        __margo_abt_unlock(&mid->abt);
         return HG_INVALID_ARG;
+    }
     if (info) {
         info->name    = mid->abt.xstreams[index].name;
         info->xstream = mid->abt.xstreams[index].xstream;
         info->index   = index;
     }
+    __margo_abt_unlock(&mid->abt);
     return HG_SUCCESS;
 }
 
@@ -269,6 +379,7 @@ hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
                                         const char*                json_str,
                                         struct margo_xstream_info* info)
 {
+    if (!mid) return HG_INVALID_ARG;
     struct json_object*     json    = NULL;
     struct json_tokener*    tokener = json_tokener_new();
     enum json_tokener_error jerr;
@@ -283,18 +394,21 @@ hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
         }
     }
     json_tokener_free(tokener);
+    __margo_abt_lock(&mid->abt);
     bool b = __margo_abt_add_xstream_from_json(&mid->abt, json);
     json_object_put(json);
+    hg_return_t ret = HG_SUCCESS;
     if (b) {
         if (info) {
             info->index   = mid->abt.xstreams_len - 1;
             info->name    = mid->abt.xstreams[info->index].name;
             info->xstream = mid->abt.xstreams[info->index].xstream;
         }
-        return HG_SUCCESS;
     } else {
-        return HG_INVALID_ARG;
+        ret = HG_INVALID_ARG;
     }
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_add_xstream_external(margo_instance_id mid,
@@ -304,7 +418,9 @@ hg_return_t margo_add_xstream_external(margo_instance_id mid,
                                        struct margo_xstream_info* info)
 {
     if (!mid) return HG_INVALID_ARG;
-    bool b = __margo_abt_add_external_xstream(&mid->abt, name, xstream);
+    __margo_abt_lock(&mid->abt);
+    hg_return_t ret = HG_SUCCESS;
+    bool        b = __margo_abt_add_external_xstream(&mid->abt, name, xstream);
     if (b) {
         mid->abt.xstreams[mid->abt.xstreams_len - 1].margo_free_flag
             = take_ownership;
@@ -313,33 +429,49 @@ hg_return_t margo_add_xstream_external(margo_instance_id mid,
             info->name    = mid->abt.xstreams[info->index].name;
             info->xstream = mid->abt.xstreams[info->index].xstream;
         }
-        return HG_SUCCESS;
     } else {
-        return HG_INVALID_ARG;
+        ret = HG_INVALID_ARG;
     }
+    __margo_abt_unlock(&mid->abt);
+    return ret;
 }
 
 hg_return_t margo_remove_xstream_by_index(margo_instance_id mid, uint32_t index)
 {
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
     bool ret = __margo_abt_remove_xstream(&mid->abt, index);
+    __margo_abt_unlock(&mid->abt);
     return ret ? HG_SUCCESS : HG_OTHER_ERROR;
 }
 
 hg_return_t margo_remove_xstream_by_name(margo_instance_id mid,
                                          const char*       name)
 {
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
     int32_t index = __margo_abt_find_xstream_by_name(&mid->abt, name);
-    if (index < 0) return HG_INVALID_ARG;
+    if (index < 0) {
+        __margo_abt_unlock(&mid->abt);
+        return HG_INVALID_ARG;
+    }
     bool ret = __margo_abt_remove_xstream(&mid->abt, index);
+    __margo_abt_unlock(&mid->abt);
     return ret ? HG_SUCCESS : HG_OTHER_ERROR;
 }
 
 hg_return_t margo_remove_xstream_by_handle(margo_instance_id mid,
                                            ABT_xstream       handle)
 {
+    if (!mid) return HG_INVALID_ARG;
+    __margo_abt_lock(&mid->abt);
     int32_t index = __margo_abt_find_xstream_by_handle(&mid->abt, handle);
-    if (index < 0) return HG_INVALID_ARG;
+    if (index < 0) {
+        __margo_abt_unlock(&mid->abt);
+        return HG_INVALID_ARG;
+    }
     bool ret = __margo_abt_remove_xstream(&mid->abt, index);
+    __margo_abt_unlock(&mid->abt);
     return ret ? HG_SUCCESS : HG_OTHER_ERROR;
 }
 

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -356,10 +356,10 @@ hg_return_t margo_transfer_pool_content(ABT_pool origin_pool,
     }
 #else
     ABT_unit unit;
-    ABT_bool is_empty;
+    size_t   pool_size;
     while (1) {
-        ABT_pool_is_empty(origin_pool, &is_empty);
-        if (is_empty == ABT_TRUE) break;
+        ABT_pool_get_size(origin_pool, &pool_size);
+        if (pool_size == 0) break;
         ABT_pool_pop(origin_pool, &unit);
         ABT_pool_push(target_pool, unit);
     }

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -356,8 +356,13 @@ hg_return_t margo_transfer_pool_content(ABT_pool origin_pool,
     }
 #else
     ABT_unit unit;
-    while (ABT_pool_pop(origin_pool, &unit) == ABT_SUCCESS)
+    ABT_bool is_empty;
+    while (1) {
+        ABT_pool_is_empty(origin_pool, &is_empty);
+        if (is_empty == ABT_TRUE) break;
+        ABT_pool_pop(origin_pool, &unit);
         ABT_pool_push(target_pool, unit);
+    }
 #endif
     return HG_SUCCESS;
 }

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -343,6 +343,25 @@ hg_return_t margo_remove_xstream_by_handle(margo_instance_id mid,
     return ret ? HG_SUCCESS : HG_OTHER_ERROR;
 }
 
+hg_return_t margo_transfer_pool_content(ABT_pool origin_pool,
+                                        ABT_pool target_pool)
+{
+#ifdef HAVE_ABT_POOL_POP_THREADS
+    while (1) {
+        ABT_thread threads[64];
+        size_t     num = 0;
+        ABT_pool_pop_threads(origin_pool, threads, 64, &num);
+        if (num == 0) break;
+        ABT_pool_push_threads(target_pool, threads, num);
+    }
+#else
+    ABT_unit unit;
+    while (ABT_pool_pop(origin_pool, &unit) == ABT_SUCCESS)
+        ABT_pool_push(target_pool, unit);
+#endif
+    return HG_SUCCESS;
+}
+
 /* DEPRECATED FUNCTIONS */
 
 // LCOV_EXCL_START

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -138,6 +138,56 @@ hg_return_t margo_find_pool_by_index(margo_instance_id       mid,
     return HG_SUCCESS;
 }
 
+hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
+                                     const char*             json_str,
+                                     struct margo_pool_info* info)
+{
+    struct json_object*     json    = NULL;
+    struct json_tokener*    tokener = json_tokener_new();
+    enum json_tokener_error jerr;
+    if (json_str && json_str[0]) {
+        json = json_tokener_parse_ex(tokener, json_str, strlen(json_str));
+        if (!json) {
+            jerr = json_tokener_get_error(tokener);
+            margo_error(mid, "JSON parse error: %s",
+                        json_tokener_error_desc(jerr));
+            json_tokener_free(tokener);
+            return HG_INVALID_ARG;
+        }
+    }
+    json_tokener_free(tokener);
+    bool b = __margo_abt_add_pool_from_json(&mid->abt, json);
+    if (b) {
+        if (info) {
+            info->index = mid->abt.pools_len - 1;
+            info->name  = mid->abt.pools[info->index].name;
+            info->pool  = mid->abt.pools[info->index].pool;
+        }
+        return HG_SUCCESS;
+    } else {
+        return HG_INVALID_ARG;
+    }
+}
+
+hg_return_t margo_add_pool_external(margo_instance_id       mid,
+                                    const char*             name,
+                                    ABT_pool                pool,
+                                    struct margo_pool_info* info)
+{
+    if (!mid) return HG_INVALID_ARG;
+    bool b = __margo_abt_add_external_pool(&mid->abt, name, pool);
+    if (b) {
+        if (info) {
+            info->index = mid->abt.pools_len - 1;
+            info->name  = mid->abt.pools[info->index].name;
+            info->pool  = mid->abt.pools[info->index].pool;
+        }
+        return HG_SUCCESS;
+    } else {
+        return HG_INVALID_ARG;
+    }
+}
+
 hg_return_t margo_find_xstream_by_handle(margo_instance_id          mid,
                                          ABT_xstream                handle,
                                          struct margo_xstream_info* info)
@@ -188,6 +238,56 @@ hg_return_t margo_find_xstream_by_index(margo_instance_id          mid,
         info->index   = index;
     }
     return HG_SUCCESS;
+}
+
+hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
+                                        const char*                json_str,
+                                        struct margo_xstream_info* info)
+{
+    struct json_object*     json    = NULL;
+    struct json_tokener*    tokener = json_tokener_new();
+    enum json_tokener_error jerr;
+    if (json_str && json_str[0]) {
+        json = json_tokener_parse_ex(tokener, json_str, strlen(json_str));
+        if (!json) {
+            jerr = json_tokener_get_error(tokener);
+            margo_error(mid, "JSON parse error: %s",
+                        json_tokener_error_desc(jerr));
+            json_tokener_free(tokener);
+            return HG_INVALID_ARG;
+        }
+    }
+    json_tokener_free(tokener);
+    bool b = __margo_abt_add_xstream_from_json(&mid->abt, json);
+    if (b) {
+        if (info) {
+            info->index   = mid->abt.xstreams_len - 1;
+            info->name    = mid->abt.xstreams[info->index].name;
+            info->xstream = mid->abt.xstreams[info->index].xstream;
+        }
+        return HG_SUCCESS;
+    } else {
+        return HG_INVALID_ARG;
+    }
+}
+
+hg_return_t margo_add_xstream_external(margo_instance_id          mid,
+                                       const char*                name,
+                                       ABT_xstream                xstream,
+                                       struct margo_xstream_info* info)
+{
+    if (!mid) return HG_INVALID_ARG;
+    bool b = __margo_abt_add_external_xstream(&mid->abt, name, xstream);
+    if (b) {
+        if (info) {
+            info->index   = mid->abt.xstreams_len - 1;
+            info->name    = mid->abt.xstreams[info->index].name;
+            info->xstream = mid->abt.xstreams[info->index].xstream;
+        }
+        return HG_SUCCESS;
+    } else {
+        return HG_INVALID_ARG;
+    }
 }
 
 /* DEPRECATED FUNCTIONS */

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -157,6 +157,7 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
     }
     json_tokener_free(tokener);
     bool b = __margo_abt_add_pool_from_json(&mid->abt, json);
+    json_object_put(json);
     if (b) {
         if (info) {
             info->index = mid->abt.pools_len - 1;
@@ -259,6 +260,7 @@ hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
     }
     json_tokener_free(tokener);
     bool b = __margo_abt_add_xstream_from_json(&mid->abt, json);
+    json_object_put(json);
     if (b) {
         if (info) {
             info->index   = mid->abt.xstreams_len - 1;

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -191,6 +191,28 @@ hg_return_t margo_add_pool_external(margo_instance_id       mid,
     }
 }
 
+hg_return_t margo_remove_pool_by_index(margo_instance_id mid, uint32_t index)
+{
+    bool ret = __margo_abt_remove_pool(&mid->abt, index);
+    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+}
+
+hg_return_t margo_remove_pool_by_name(margo_instance_id mid, const char* name)
+{
+    int32_t index = __margo_abt_find_pool_by_name(&mid->abt, name);
+    if (index < 0) return HG_INVALID_ARG;
+    bool ret = __margo_abt_remove_pool(&mid->abt, index);
+    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+}
+
+hg_return_t margo_remove_pool_by_handle(margo_instance_id mid, ABT_pool handle)
+{
+    int32_t index = __margo_abt_find_pool_by_handle(&mid->abt, handle);
+    if (index < 0) return HG_INVALID_ARG;
+    bool ret = __margo_abt_remove_pool(&mid->abt, index);
+    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+}
+
 hg_return_t margo_find_xstream_by_handle(margo_instance_id          mid,
                                          ABT_xstream                handle,
                                          struct margo_xstream_info* info)
@@ -295,6 +317,30 @@ hg_return_t margo_add_xstream_external(margo_instance_id mid,
     } else {
         return HG_INVALID_ARG;
     }
+}
+
+hg_return_t margo_remove_xstream_by_index(margo_instance_id mid, uint32_t index)
+{
+    bool ret = __margo_abt_remove_xstream(&mid->abt, index);
+    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+}
+
+hg_return_t margo_remove_xstream_by_name(margo_instance_id mid,
+                                         const char*       name)
+{
+    int32_t index = __margo_abt_find_xstream_by_name(&mid->abt, name);
+    if (index < 0) return HG_INVALID_ARG;
+    bool ret = __margo_abt_remove_xstream(&mid->abt, index);
+    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
+}
+
+hg_return_t margo_remove_xstream_by_handle(margo_instance_id mid,
+                                           ABT_xstream       handle)
+{
+    int32_t index = __margo_abt_find_xstream_by_handle(&mid->abt, handle);
+    if (index < 0) return HG_INVALID_ARG;
+    bool ret = __margo_abt_remove_xstream(&mid->abt, index);
+    return ret ? HG_SUCCESS : HG_OTHER_ERROR;
 }
 
 /* DEPRECATED FUNCTIONS */

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -173,11 +173,13 @@ hg_return_t margo_add_pool_from_json(margo_instance_id       mid,
 hg_return_t margo_add_pool_external(margo_instance_id       mid,
                                     const char*             name,
                                     ABT_pool                pool,
+                                    ABT_bool                take_ownership,
                                     struct margo_pool_info* info)
 {
     if (!mid) return HG_INVALID_ARG;
     bool b = __margo_abt_add_external_pool(&mid->abt, name, pool);
     if (b) {
+        mid->abt.pools[mid->abt.pools_len - 1].margo_free_flag = take_ownership;
         if (info) {
             info->index = mid->abt.pools_len - 1;
             info->name  = mid->abt.pools[info->index].name;
@@ -273,14 +275,17 @@ hg_return_t margo_add_xstream_from_json(margo_instance_id          mid,
     }
 }
 
-hg_return_t margo_add_xstream_external(margo_instance_id          mid,
-                                       const char*                name,
-                                       ABT_xstream                xstream,
+hg_return_t margo_add_xstream_external(margo_instance_id mid,
+                                       const char*       name,
+                                       ABT_xstream       xstream,
+                                       ABT_bool          take_ownership,
                                        struct margo_xstream_info* info)
 {
     if (!mid) return HG_INVALID_ARG;
     bool b = __margo_abt_add_external_xstream(&mid->abt, name, xstream);
     if (b) {
+        mid->abt.xstreams[mid->abt.xstreams_len - 1].margo_free_flag
+            = take_ownership;
         if (info) {
             info->index   = mid->abt.xstreams_len - 1;
             info->name    = mid->abt.xstreams[info->index].name;

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -2200,8 +2200,16 @@ hg_return_t margo_rpc_set_pool(margo_instance_id mid, hg_id_t id, ABT_pool pool)
         = (struct margo_rpc_data*)HG_Registered_data(margo_get_class(mid), id);
     if (!data) return HG_NOENTRY;
     if (pool == ABT_POOL_NULL) margo_get_handler_pool(mid, &pool);
+    int old_pool_entry_idx
+        = __margo_abt_find_pool_by_handle(&mid->abt, data->pool);
+    int new_pool_entry_idx = __margo_abt_find_pool_by_handle(&mid->abt, pool);
+    if (old_pool_entry_idx >= 0)
+        mid->abt.pools[old_pool_entry_idx].num_rpc_ids -= 1;
+    if (new_pool_entry_idx >= 0)
+        mid->abt.pools[new_pool_entry_idx].num_rpc_ids += 1;
+    else
+        margo_warning(mid, "Associating RPC with a pool not know to Margo");
     data->pool = pool;
-    ;
     return HG_SUCCESS;
 }
 

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -123,6 +123,8 @@ static void margo_cleanup(margo_instance_id mid)
     struct margo_monitor_finalize_args monitoring_args = {};
     __MARGO_MONITOR(mid, FN_START, finalize, monitoring_args);
 
+    margo_deregister(mid, mid->shutdown_rpc_id);
+
     /* call finalize callbacks */
     MARGO_TRACE(mid, "Calling finalize callbacks");
     struct margo_finalize_cb* fcb = mid->finalize_cb;

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -544,11 +544,10 @@ hg_return_t margo_deregister(margo_instance_id mid, hg_id_t rpc_id)
         = (struct margo_rpc_data*)HG_Registered_data(mid->hg.hg_class, rpc_id);
     if (data) {
         /* decrement the numner of RPC id used by the pool */
-        struct margo_pool_info pool_info;
-        if (margo_find_pool_by_handle(mid, data->pool, &pool_info)
-            == HG_SUCCESS) {
-            mid->abt.pools[pool_info.index].num_rpc_ids -= 1;
-        }
+        __margo_abt_lock(&mid->abt);
+        int32_t index = __margo_abt_find_pool_by_handle(&mid->abt, data->pool);
+        if (index >= 0) mid->abt.pools[index].num_rpc_ids -= 1;
+        __margo_abt_unlock(&mid->abt);
     }
 
     /* deregister */
@@ -2199,6 +2198,7 @@ hg_return_t margo_rpc_set_pool(margo_instance_id mid, hg_id_t id, ABT_pool pool)
     struct margo_rpc_data* data
         = (struct margo_rpc_data*)HG_Registered_data(margo_get_class(mid), id);
     if (!data) return HG_NOENTRY;
+    __margo_abt_lock(&mid->abt);
     if (pool == ABT_POOL_NULL) margo_get_handler_pool(mid, &pool);
     int old_pool_entry_idx
         = __margo_abt_find_pool_by_handle(&mid->abt, data->pool);
@@ -2209,6 +2209,7 @@ hg_return_t margo_rpc_set_pool(margo_instance_id mid, hg_id_t id, ABT_pool pool)
         mid->abt.pools[new_pool_entry_idx].num_rpc_ids += 1;
     else
         margo_warning(mid, "Associating RPC with a pool not know to Margo");
+    __margo_abt_unlock(&mid->abt);
     data->pool = pool;
     return HG_SUCCESS;
 }

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -4,6 +4,7 @@ check_PROGRAMS += \
  tests/unit-tests/margo-addr \
  tests/unit-tests/margo-init \
  tests/unit-tests/margo-config \
+ tests/unit-tests/margo-elasticity \
  tests/unit-tests/margo-pool \
  tests/unit-tests/margo-abt-pool \
  tests/unit-tests/margo-eventual \
@@ -21,6 +22,7 @@ TESTS += \
  tests/unit-tests/margo-addr \
  tests/unit-tests/margo-init \
  tests/unit-tests/margo-config \
+ tests/unit-tests/margo-elasticity \
  tests/unit-tests/margo-pool \
  tests/unit-tests/margo-abt-pool \
  tests/unit-tests/margo-eventual \
@@ -46,6 +48,11 @@ tests_unit_tests_margo_init_SOURCES = \
 tests_unit_tests_margo_config_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-config.c \
+ tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_elasticity_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-elasticity.c \
  tests/unit-tests/helper-server.c
 
 tests_unit_tests_margo_pool_SOURCES = \

--- a/tests/unit-tests/margo-elasticity.c
+++ b/tests/unit-tests/margo-elasticity.c
@@ -250,14 +250,13 @@ static MunitResult remove_pool(const MunitParameter params[], void* data)
 
     // failing case: put a ULT in my_pool_2 and try to remove the pool
     // Note: because my_pool_2 isn't used by any ES, the thread isn't
-    // going to start executing, so we then need to pop it out of the pool
-    // manually and push it into one that has an ES attached (the handler pool).
+    // going to start executing, so we then need to transfer the content
+    // of my_pool_2 into a pool that will actually be able to run the work.
     ABT_thread_create(pool_info.pool, my_ult, NULL, ABT_THREAD_ATTR_NULL, NULL);
     ret = margo_remove_pool_by_index(mid, pool_info.index);
     munit_assert_int(ret, !=, HG_SUCCESS);
-    ABT_unit ult;
-    ABT_pool_pop(pool_info.pool, &ult);
-    ABT_pool_push(handler_pool, ult);
+    ret = margo_transfer_pool_content(pool_info.pool, handler_pool);
+    munit_assert_int(ret, ==, HG_SUCCESS);
 
     // remove my_pool_2 by index
     ret = margo_remove_pool_by_index(mid, pool_info.index);

--- a/tests/unit-tests/margo-elasticity.c
+++ b/tests/unit-tests/margo-elasticity.c
@@ -1,0 +1,309 @@
+
+#include <margo.h>
+#include "munit/munit.h"
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void) params;
+    (void) user_data;
+    return NULL;
+}
+
+static void test_context_tear_down(void *data)
+{
+    (void)data;
+}
+
+static MunitResult add_pool_from_json(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+
+    margo_instance_id mid = margo_init("na+sm", MARGO_SERVER_MODE, 1, 4);
+    munit_assert_not_null(mid);
+
+    hg_return_t ret;
+
+    // add a pool from a JSON string
+    struct margo_pool_info pool_info = {0};
+    const char* pool_desc = "{\"name\":\"my_pool\", \"kind\":\"fifo_wait\", \"access\": \"mpmc\"}";
+    ret = margo_add_pool_from_json(mid, pool_desc, &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info.index, ==, 3);
+    munit_assert_string_equal(pool_info.name, "my_pool");
+    munit_assert_not_null(pool_info.pool);
+
+    // search for it by index
+    struct margo_pool_info pool_info2 = {0};
+    ret = margo_find_pool_by_index(mid, pool_info.index, &pool_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info2.index, ==, pool_info.index);
+    munit_assert_string_equal(pool_info2.name, pool_info.name);
+    munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
+
+    // search for it by name
+    memset(&pool_info2, 0, sizeof(pool_info2));
+    ret = margo_find_pool_by_name(mid, pool_info.name, &pool_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info2.index, ==, pool_info.index);
+    munit_assert_string_equal(pool_info2.name, pool_info.name);
+    munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
+
+    // search for it by handle
+    memset(&pool_info2, 0, sizeof(pool_info2));
+    ret = margo_find_pool_by_handle(mid, pool_info.pool, &pool_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info2.index, ==, pool_info.index);
+    munit_assert_string_equal(pool_info2.name, pool_info.name);
+    munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
+
+    // add a pool with an invalid JSON
+    ret = margo_add_pool_from_json(mid, pool_desc, &pool_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // add a pool with a name already in use (reuse pool_desc)
+    ret = margo_add_pool_from_json(mid, pool_desc, &pool_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // add a pool without a name (name will be generated)
+    ret = margo_add_pool_from_json(mid, "{}", &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_string_equal(pool_info.name, "__pool_4__");
+
+    // add a pool with a NULL config (should be equivalent to {})
+    ret = margo_add_pool_from_json(mid, NULL, &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_string_equal(pool_info.name, "__pool_5__");
+
+    margo_finalize(mid);
+    return MUNIT_OK;
+}
+
+static MunitResult add_pool_external(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+
+    margo_instance_id mid = margo_init("na+sm", MARGO_SERVER_MODE, 1, 4);
+    munit_assert_not_null(mid);
+
+    // create pool
+    ABT_pool my_pool = ABT_POOL_NULL;
+    int r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE, &my_pool);
+    munit_assert_int(r, ==, ABT_SUCCESS);
+
+    hg_return_t ret;
+
+    // add an external pool
+    struct margo_pool_info pool_info = {0};
+    ret = margo_add_pool_external(mid, "my_pool", my_pool, &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info.index, ==, 3);
+    munit_assert_string_equal(pool_info.name, "my_pool");
+    munit_assert_ptr_equal(pool_info.pool, my_pool);
+
+    // search for it by index
+    struct margo_pool_info pool_info2 = {0};
+    ret = margo_find_pool_by_index(mid, pool_info.index, &pool_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info2.index, ==, pool_info.index);
+    munit_assert_string_equal(pool_info2.name, pool_info.name);
+    munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
+
+    // search for it by name
+    memset(&pool_info2, 0, sizeof(pool_info2));
+    ret = margo_find_pool_by_name(mid, pool_info.name, &pool_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info2.index, ==, pool_info.index);
+    munit_assert_string_equal(pool_info2.name, pool_info.name);
+    munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
+
+    // search for it by handle
+    memset(&pool_info2, 0, sizeof(pool_info2));
+    ret = margo_find_pool_by_handle(mid, pool_info.pool, &pool_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(pool_info2.index, ==, pool_info.index);
+    munit_assert_string_equal(pool_info2.name, pool_info.name);
+    munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
+
+    // try to add the same handle with a different name
+    ret = margo_add_pool_external(mid, "my_pool2", my_pool, &pool_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // create second pool
+    ABT_pool my_pool2 = ABT_POOL_NULL;
+    r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE, &my_pool2);
+    munit_assert_int(r, ==, ABT_SUCCESS);
+
+    // try to add it with a name that exists
+    ret = margo_add_pool_external(mid, "my_pool", my_pool2, &pool_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // since my_pool2 hasn't been associated with any ES, we should free it manually
+    ABT_pool_free(&my_pool2);
+
+    margo_finalize(mid);
+    return MUNIT_OK;
+}
+
+static MunitResult add_xstream_from_json(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+
+    margo_instance_id mid = margo_init("na+sm", MARGO_SERVER_MODE, 1, 4);
+    munit_assert_not_null(mid);
+
+    hg_return_t ret;
+
+    // add an xstream from a JSON string
+    struct margo_xstream_info xstream_info = {0};
+    const char* xstream_desc = "{\"name\":\"my_es\", \"scheduler\":{\"pools\":[\"__primary__\", \"__pool_1__\"]}}";
+    ret = margo_add_xstream_from_json(mid, xstream_desc, &xstream_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info.index, ==, 6);
+    munit_assert_string_equal(xstream_info.name, "my_es");
+    munit_assert_not_null(xstream_info.xstream);
+
+    // search for it by index
+    struct margo_xstream_info xstream_info2 = {0};
+    ret = margo_find_xstream_by_index(mid, xstream_info.index, &xstream_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info2.index, ==, xstream_info.index);
+    munit_assert_string_equal(xstream_info2.name, xstream_info.name);
+    munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
+
+    // search for it by name
+    memset(&xstream_info2, 0, sizeof(xstream_info2));
+    ret = margo_find_xstream_by_name(mid, xstream_info.name, &xstream_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info2.index, ==, xstream_info.index);
+    munit_assert_string_equal(xstream_info2.name, xstream_info.name);
+    munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
+
+    // search for it by handle
+    memset(&xstream_info2, 0, sizeof(xstream_info2));
+    ret = margo_find_xstream_by_handle(mid, xstream_info.xstream, &xstream_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info2.index, ==, xstream_info.index);
+    munit_assert_string_equal(xstream_info2.name, xstream_info.name);
+    munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
+
+    // add a xstream with an invalid JSON
+    ret = margo_add_xstream_from_json(mid, xstream_desc, &xstream_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // add a xstream with a name already in use (reuse xstream_desc)
+    ret = margo_add_xstream_from_json(mid, xstream_desc, &xstream_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // add a xstream without a name (name will be generated)
+    ret = margo_add_xstream_from_json(mid, "{\"scheduler\":{\"pools\":[\"__primary__\"]}}", &xstream_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_string_equal(xstream_info.name, "__xstream_7__");
+
+    // add a xstream with a NULL config (not allowed)
+    ret = margo_add_xstream_from_json(mid, NULL, &xstream_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    margo_finalize(mid);
+    return MUNIT_OK;
+}
+
+static MunitResult add_xstream_external(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+    hg_return_t ret;
+
+    margo_instance_id mid = margo_init("na+sm", MARGO_SERVER_MODE, 1, 4);
+    munit_assert_not_null(mid);
+
+    // we will need to use pools that are known by Margo
+    ABT_pool known_pools[3];
+    for(int i = 0; i < 3; i++) {
+        struct margo_pool_info pool_info = {0};
+        ret = margo_find_pool_by_index(mid, i, &pool_info);
+        munit_assert_int(ret, ==, HG_SUCCESS);
+        known_pools[i] = pool_info.pool;
+    }
+
+    // create xstream
+    ABT_xstream my_xstream = ABT_XSTREAM_NULL;
+    int r = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &known_pools[2], ABT_SCHED_CONFIG_NULL, &my_xstream);
+    munit_assert_int(r, ==, ABT_SUCCESS);
+
+    // add external xstream
+    struct margo_xstream_info xstream_info = {0};
+    ret = margo_add_xstream_external(mid, "my_xstream", my_xstream, &xstream_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info.index, ==, 6);
+    munit_assert_string_equal(xstream_info.name, "my_xstream");
+    munit_assert_ptr_equal(xstream_info.xstream, my_xstream);
+
+    // search for it by index
+    struct margo_xstream_info xstream_info2 = {0};
+    ret = margo_find_xstream_by_index(mid, xstream_info.index, &xstream_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info2.index, ==, xstream_info.index);
+    munit_assert_string_equal(xstream_info2.name, xstream_info.name);
+    munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
+
+    // search for it by name
+    memset(&xstream_info2, 0, sizeof(xstream_info2));
+    ret = margo_find_xstream_by_name(mid, xstream_info.name, &xstream_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info2.index, ==, xstream_info.index);
+    munit_assert_string_equal(xstream_info2.name, xstream_info.name);
+    munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
+
+    // search for it by handle
+    memset(&xstream_info2, 0, sizeof(xstream_info2));
+    ret = margo_find_xstream_by_handle(mid, xstream_info.xstream, &xstream_info2);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+    munit_assert_int(xstream_info2.index, ==, xstream_info.index);
+    munit_assert_string_equal(xstream_info2.name, xstream_info.name);
+    munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
+
+    // try to add the same handle with a different name
+    ret = margo_add_xstream_external(mid, "my_xstream2", my_xstream, &xstream_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // create second xstream
+    ABT_xstream my_xstream2 = ABT_XSTREAM_NULL;
+    r = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &known_pools[2], ABT_SCHED_CONFIG_NULL, &my_xstream2);
+    munit_assert_int(r, ==, ABT_SUCCESS);
+
+    // try to add it with a name that exists
+    ret = margo_add_xstream_external(mid, "my_xstream", my_xstream2, &xstream_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // since my_xstream2 hasn't been added, free it manually
+    ABT_xstream_join(my_xstream2);
+    ABT_xstream_free(&my_xstream2);
+
+    // TODO: Margo still has a reference to the xstream here so this is dangerous
+    ABT_xstream_join(my_xstream);
+    ABT_xstream_free(&my_xstream);
+
+    margo_finalize(mid);
+    return MUNIT_OK;
+}
+
+static MunitTest tests[] = {
+    { "/add_pool_from_json", add_pool_from_json, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { "/add_pool_external", add_pool_external, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { "/add_xstream_from_json", add_xstream_from_json, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { "/add_xstream_external", add_xstream_external, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};
+
+static const MunitSuite test_suite = {
+    "/margo", tests, NULL, 1, MUNIT_SUITE_OPTION_NONE
+};
+
+
+int main(int argc, char **argv)
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}

--- a/tests/unit-tests/margo-elasticity.c
+++ b/tests/unit-tests/margo-elasticity.c
@@ -278,6 +278,20 @@ static MunitResult add_xstream_external(const MunitParameter params[], void* dat
     ret = margo_add_xstream_external(mid, "my_xstream", my_xstream2, true, &xstream_info);
     munit_assert_int(ret, ==, HG_INVALID_ARG);
 
+    // create an xstream with a pool that hasn't been registed and try to add it
+    ABT_pool my_pool = ABT_POOL_NULL;
+    r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE, &my_pool);
+    munit_assert_int(r, ==, ABT_SUCCESS);
+    ABT_xstream my_xstream3 = ABT_XSTREAM_NULL;
+    r = ABT_xstream_create_basic(ABT_SCHED_PRIO, 1, &my_pool, ABT_SCHED_CONFIG_NULL, &my_xstream3);
+    munit_assert_int(r, ==, ABT_SUCCESS);
+    ret = margo_add_xstream_external(mid, "my_xstream_3", my_xstream3, true, &xstream_info);
+    munit_assert_int(ret, ==, HG_INVALID_ARG);
+
+    // since my_xstream3 hasn't been added, free it manually
+    ABT_xstream_join(my_xstream3);
+    ABT_xstream_free(&my_xstream3);
+
     // since my_xstream2 hasn't been added, free it manually
     ABT_xstream_join(my_xstream2);
     ABT_xstream_free(&my_xstream2);

--- a/tests/unit-tests/margo-elasticity.c
+++ b/tests/unit-tests/margo-elasticity.c
@@ -89,14 +89,14 @@ static MunitResult add_pool_external(const MunitParameter params[], void* data)
 
     // create pool
     ABT_pool my_pool = ABT_POOL_NULL;
-    int r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE, &my_pool);
+    int r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_FALSE, &my_pool);
     munit_assert_int(r, ==, ABT_SUCCESS);
 
     hg_return_t ret;
 
     // add an external pool
     struct margo_pool_info pool_info = {0};
-    ret = margo_add_pool_external(mid, "my_pool", my_pool, &pool_info);
+    ret = margo_add_pool_external(mid, "my_pool", my_pool, true, &pool_info);
     munit_assert_int(ret, ==, HG_SUCCESS);
     munit_assert_int(pool_info.index, ==, 3);
     munit_assert_string_equal(pool_info.name, "my_pool");
@@ -127,16 +127,16 @@ static MunitResult add_pool_external(const MunitParameter params[], void* data)
     munit_assert_ptr_equal(pool_info2.pool, pool_info.pool);
 
     // try to add the same handle with a different name
-    ret = margo_add_pool_external(mid, "my_pool2", my_pool, &pool_info);
+    ret = margo_add_pool_external(mid, "my_pool2", my_pool, true, &pool_info);
     munit_assert_int(ret, ==, HG_INVALID_ARG);
 
     // create second pool
     ABT_pool my_pool2 = ABT_POOL_NULL;
-    r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE, &my_pool2);
+    r = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_FALSE, &my_pool2);
     munit_assert_int(r, ==, ABT_SUCCESS);
 
     // try to add it with a name that exists
-    ret = margo_add_pool_external(mid, "my_pool", my_pool2, &pool_info);
+    ret = margo_add_pool_external(mid, "my_pool", my_pool2, true, &pool_info);
     munit_assert_int(ret, ==, HG_INVALID_ARG);
 
     // since my_pool2 hasn't been associated with any ES, we should free it manually
@@ -235,7 +235,7 @@ static MunitResult add_xstream_external(const MunitParameter params[], void* dat
 
     // add external xstream
     struct margo_xstream_info xstream_info = {0};
-    ret = margo_add_xstream_external(mid, "my_xstream", my_xstream, &xstream_info);
+    ret = margo_add_xstream_external(mid, "my_xstream", my_xstream, true, &xstream_info);
     munit_assert_int(ret, ==, HG_SUCCESS);
     munit_assert_int(xstream_info.index, ==, 6);
     munit_assert_string_equal(xstream_info.name, "my_xstream");
@@ -266,7 +266,7 @@ static MunitResult add_xstream_external(const MunitParameter params[], void* dat
     munit_assert_ptr_equal(xstream_info2.xstream, xstream_info.xstream);
 
     // try to add the same handle with a different name
-    ret = margo_add_xstream_external(mid, "my_xstream2", my_xstream, &xstream_info);
+    ret = margo_add_xstream_external(mid, "my_xstream2", my_xstream, true, &xstream_info);
     munit_assert_int(ret, ==, HG_INVALID_ARG);
 
     // create second xstream
@@ -275,16 +275,12 @@ static MunitResult add_xstream_external(const MunitParameter params[], void* dat
     munit_assert_int(r, ==, ABT_SUCCESS);
 
     // try to add it with a name that exists
-    ret = margo_add_xstream_external(mid, "my_xstream", my_xstream2, &xstream_info);
+    ret = margo_add_xstream_external(mid, "my_xstream", my_xstream2, true, &xstream_info);
     munit_assert_int(ret, ==, HG_INVALID_ARG);
 
     // since my_xstream2 hasn't been added, free it manually
     ABT_xstream_join(my_xstream2);
     ABT_xstream_free(&my_xstream2);
-
-    // TODO: Margo still has a reference to the xstream here so this is dangerous
-    ABT_xstream_join(my_xstream);
-    ABT_xstream_free(&my_xstream);
 
     margo_finalize(mid);
     return MUNIT_OK;

--- a/tests/unit-tests/margo-elasticity.c
+++ b/tests/unit-tests/margo-elasticity.c
@@ -146,6 +146,106 @@ static MunitResult add_pool_external(const MunitParameter params[], void* data)
     return MUNIT_OK;
 }
 
+static MunitResult remove_pool(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+
+    margo_instance_id mid = margo_init("na+sm", MARGO_SERVER_MODE, 1, 4);
+    munit_assert_not_null(mid);
+
+    hg_return_t ret;
+
+    // note: because pools need to not be attached to any ES to be removed,
+    // we can't just act on the pools created by margo_init. We will have
+    // to create a few pools attached to nothing so we can remove them.
+
+    struct margo_pool_info pool_info = {0};
+
+    // add a few pools from a JSON string
+    for(unsigned i = 0; i < 3; i++) {
+        const char* pool_desc_fmt = "{\"name\":\"my_pool_%u\", \"kind\":\"fifo_wait\", \"access\": \"mpmc\"}";
+        char pool_desc[1024];
+        sprintf(pool_desc, pool_desc_fmt, i);
+        ret = margo_add_pool_from_json(mid, pool_desc, &pool_info);
+        munit_assert_int(ret, ==, HG_SUCCESS);
+        munit_assert_int(pool_info.index, ==, 3 + i);
+    }
+
+    int num_pools = margo_get_num_pools(mid);
+    munit_assert_int(num_pools, ==, 6);
+
+    // failing case: removing by invalid index
+    ret = margo_remove_pool_by_index(mid, num_pools);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing by invalid name
+    ret = margo_remove_pool_by_name(mid, "invalid");
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing by invalid ABT_pool
+    ret = margo_remove_pool_by_handle(mid, (ABT_pool)(0x1234));
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing the primary ES's pool
+    ret = margo_remove_pool_by_name(mid, "__primary__");
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing a pool that is still in use by some ES
+    ret = margo_remove_pool_by_name(mid, "__pool_1__");
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // check that we can access my_pool_1
+    ret = margo_find_pool_by_name(mid, "my_pool_1", &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // remove my_pool_1 by name
+    ret = margo_remove_pool_by_name(mid, "my_pool_1");
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // check the number of pools again
+    num_pools = margo_get_num_pools(mid);
+    munit_assert_int(num_pools, ==, 5);
+
+    // check that my_pool_1 is no longer present
+    ret = margo_find_pool_by_name(mid, "my_pool_1", &pool_info);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // check that we can access my_pool_2
+    ret = margo_find_pool_by_name(mid, "my_pool_2", &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // remove my_pool_2 by index
+    ret = margo_remove_pool_by_index(mid, pool_info.index);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // check the number of xstreams again
+    num_pools = margo_get_num_pools(mid);
+    munit_assert_int(num_pools, ==, 4);
+
+    // check that my_pool_2 is no longer present
+    ret = margo_find_pool_by_name(mid, "my_pool_2", &pool_info);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // check that we can access my_pool_0
+    ret = margo_find_pool_by_name(mid, "my_pool_0", &pool_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // remove it by handle
+    ret = margo_remove_pool_by_handle(mid, pool_info.pool);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // check the number of pools again
+    num_pools = margo_get_num_pools(mid);
+    munit_assert_int(num_pools, ==, 3);
+
+    // check that my_pool_0 is no longer present
+    ret = margo_find_pool_by_name(mid, "my_pool_0", &pool_info);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    margo_finalize(mid);
+    return MUNIT_OK;
+}
 static MunitResult add_xstream_from_json(const MunitParameter params[], void* data)
 {
     (void)params;
@@ -300,11 +400,99 @@ static MunitResult add_xstream_external(const MunitParameter params[], void* dat
     return MUNIT_OK;
 }
 
+static MunitResult remove_xstream(const MunitParameter params[], void* data)
+{
+    (void)params;
+    (void)data;
+    hg_return_t ret;
+
+    margo_instance_id mid = margo_init("na+sm", MARGO_SERVER_MODE, 1, 4);
+    munit_assert_not_null(mid);
+
+    // note: in this setup, margo has a __primary__ ES and __xstream_X__
+    // with X = 1 (progress loop), 2, 3, 4, 5 (RPC xstreams).
+    // We should NOT remove __xstream_1__ if we don't want the test to
+    // deadlock, but we are safe removing 2, 3, 4, and 5.
+
+    int num_xstreams = margo_get_num_xstreams(mid);
+    munit_assert_int(num_xstreams, ==, 6);
+
+    // failing case: removing by invalid index
+    ret = margo_remove_xstream_by_index(mid, num_xstreams);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing by invalid name
+    ret = margo_remove_xstream_by_name(mid, "invalid");
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing by invalid ABT_xstream
+    ret = margo_remove_xstream_by_handle(mid, (ABT_xstream)(0x1234));
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // failing case: removing the primary ES
+    ret = margo_remove_xstream_by_name(mid, "__primary__");
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // check that we can access __xstream_2__
+    struct margo_xstream_info xstream_info = {0};
+    ret = margo_find_xstream_by_name(mid, "__xstream_2__", &xstream_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // remove __xstream_2__ by name
+    ret = margo_remove_xstream_by_name(mid, "__xstream_2__");
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // check the number of xstreams again
+    num_xstreams = margo_get_num_xstreams(mid);
+    munit_assert_int(num_xstreams, ==, 5);
+
+    // check that __xstream_2__ is no longer present
+    ret = margo_find_xstream_by_name(mid, "__xstream_2__", &xstream_info);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // check that we can access __xstream_4__
+    ret = margo_find_xstream_by_name(mid, "__xstream_4__", &xstream_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // remove __xstream_4__ by index
+    ret = margo_remove_xstream_by_index(mid, xstream_info.index);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // check the number of xstreams again
+    num_xstreams = margo_get_num_xstreams(mid);
+    munit_assert_int(num_xstreams, ==, 4);
+
+    // check that __xstream_4__ is no longer present
+    ret = margo_find_xstream_by_name(mid, "__xstream_4__", &xstream_info);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    // check that we can access __xstream_3__
+    ret = margo_find_xstream_by_name(mid, "__xstream_3__", &xstream_info);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // remove it by handle
+    ret = margo_remove_xstream_by_handle(mid, xstream_info.xstream);
+    munit_assert_int(ret, ==, HG_SUCCESS);
+
+    // check the number of xstreams again
+    num_xstreams = margo_get_num_xstreams(mid);
+    munit_assert_int(num_xstreams, ==, 3);
+
+    // check that __xstream_3__ is no longer present
+    ret = margo_find_xstream_by_name(mid, "__xstream_3__", &xstream_info);
+    munit_assert_int(ret, !=, HG_SUCCESS);
+
+    margo_finalize(mid);
+    return MUNIT_OK;
+}
+
 static MunitTest tests[] = {
     { "/add_pool_from_json", add_pool_from_json, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     { "/add_pool_external", add_pool_external, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { "/remove_pool", remove_pool, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     { "/add_xstream_from_json", add_xstream_from_json, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     { "/add_xstream_external", add_xstream_external, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
+    { "/remove_xstream", remove_xstream, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, NULL},
     { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };
 

--- a/tests/unit-tests/margo-elasticity.c
+++ b/tests/unit-tests/margo-elasticity.c
@@ -255,9 +255,9 @@ static MunitResult remove_pool(const MunitParameter params[], void* data)
     ABT_thread_create(pool_info.pool, my_ult, NULL, ABT_THREAD_ATTR_NULL, NULL);
     ret = margo_remove_pool_by_index(mid, pool_info.index);
     munit_assert_int(ret, !=, HG_SUCCESS);
-    ABT_thread tmp_ult;
-    ABT_pool_pop_thread(pool_info.pool, &tmp_ult);
-    ABT_pool_push_thread(handler_pool, tmp_ult);
+    ABT_unit ult;
+    ABT_pool_pop(pool_info.pool, &ult);
+    ABT_pool_push(handler_pool, ult);
 
     // remove my_pool_2 by index
     ret = margo_remove_pool_by_index(mid, pool_info.index);


### PR DESCRIPTION
This PR brings the following functions in `margo-config.h`:
- `margo_add_pool_from_json`: adds (create) a pool using a JSON description (same as pool definitions in margo config);
- `margo_add_pool_external`: makes margo aware of an externally-initialized pool (also provides the option to give ownership of this pool to the margo instance);
- `margo_add_xstream_from_json`: adds (create) an xstream using a JSON description (same as xstream definitions in margo config);
- `margo_add_xstream_external`: makes margo aware of an externally-initialized xstream (also provides the option to give ownership of this xstream to the margo instance);
- `margo_remove_pool_by_index/name/handle`: removes a pool specified by its index or name or handle (free the pool if margo has ownership of it);
- `margo_remove_xstream_by_index/name/handle`: removes an xstream specified by its index or name or handle (joins then frees the xstream if margo has ownership of it);

Constraints:
- Cannot add a pool/xstream with the same name as an existing pool/xstream;
- Cannot add the same external pool/xstream multiple times;
- Cannot add an external xstream if its pools are not known to margo first;
- Cannot remove a pool that is used by some xstreams;
- Cannot remove a pool that is used by some RPC handlers;
- Cannot remove a pool that is not empty (including blocked ULTs);
- Cannot remove the progress pool and the default handler pool;
- Cannot remove the primary ES.

Margo makes the best attempt at preventing inconsistent states but since the user has access to the ABT_pool and ABT_xstream handles, there is pretty much nothing preventing a user from getting around the above constraints. For instance, a user could always get a margo-managed xstream and use `ABT_xstream_set_sched` to change its scheduler and the pools it is associated with, including pools that are not known to Margo. The user could also keep around an ABT_pool handle to a pool that has been removed.

This is a WIP. Remaining functionalities to implement include:

- [ ] ~~Allowing changing the scheduler of an existing xstream;~~ (not easy with current Argobots API)
- [x] Making sure `margo_rpc_set_pool` correctly update the count of RPCs registered with a pool;
- [x] Adding a function to transfer ULTs from a pool to another;
- [x] Adding proper locks around modifications of the xstreams and pools.