### PR TITLE
[BUG] Using the full 64 bits of hg_id_t for the hash

### DIFF
--- a/src/margo-id.h
+++ b/src/margo-id.h
@@ -38,8 +38,9 @@ static inline hg_id_t gen_id(const char* func_name, uint16_t provider_id)
     unsigned hashval;
 
     HASH_JEN(func_name, strlen(func_name), hashval);
-    id = hashval << (__MARGO_PROVIDER_ID_SIZE * 8);
-    id |= provider_id;
+    id = hashval;
+    id = id << 32;
+    id |= (hg_id_t)provider_id;
 
     return id;
 }

--- a/src/margo-id.h
+++ b/src/margo-id.h
@@ -6,6 +6,8 @@
 #ifndef __MARGO_ID_H
 #define __MARGO_ID_H
 
+#include <mercury.h>
+
 static inline void demux_id(hg_id_t in, hg_id_t* base_id, uint16_t* provider_id)
 {
     /* retrieve low bits for provider */
@@ -38,9 +40,20 @@ static inline hg_id_t gen_id(const char* func_name, uint16_t provider_id)
     unsigned hashval;
 
     HASH_JEN(func_name, strlen(func_name), hashval);
+    // Imporant: until Mercury 2.3.0, there was a bug causing Mercury to
+    // cast hg_id_t into a 32-bit value somewhere, causing half of its bytes
+    // to get discarded. The two ways of generating the ID hereafter account
+    // for this.
+#if (HG_VERSION_MAJOR > 2) || (HG_VERSION_MAJOR == 2 && HG_VERSION_MINOR >= 3)
+    // version for Mercury 2.3.0 and above
     id = hashval;
     id = id << 32;
     id |= (hg_id_t)provider_id;
+#else
+    // old version
+    id = hashval << (__MARGO_PROVIDER_ID_SIZE * 8);
+    id |= provider_id;
+#endif
 
     return id;
 }


### PR DESCRIPTION
DO NO MERGE UNTIL RESOLVED

This is a merge request to force github actions to run, but right now it's a bug. I have changed the `gen_id` function in `margo-id.h` from this:

```
static inline hg_id_t gen_id(const char* func_name, uint16_t provider_id)
{
    hg_id_t  id;
    unsigned hashval;

    HASH_JEN(func_name, strlen(func_name), hashval);
    id = hashval << (__MARGO_PROVIDER_ID_SIZE * 8);
    id |= provider_id;

    return id;
}
```

to this:

```
static inline hg_id_t gen_id(const char* func_name, uint16_t provider_id)
{
    hg_id_t  id;
    unsigned hashval;

    HASH_JEN(func_name, strlen(func_name), hashval);
    id = hashval;
    id = id << 32;
    id |= (hg_id_t)provider_id;

    return id;
}
```

In the original version `hashval << (__MARGO_PROVIDER_ID_SIZE * 8)` is executed before the result is assigned to `id`. Since `hashval` is an `unsigned`, it's 32 bits, so we are discarding 2 bytes of it, leaving only 2 bytes worth of entropy. The way the function is written at the moment, an RPC id will never have a value higher than 4,294,967,295.

In the second version, I first assign `hashval` to `id`, making it a 64 bits value (though at this point it still cannot exceed 4,294,967,295), then I shift it left 32 bits, effectively shifting the set bytes to the 4 most significant, and finally I set the provider id to the 2 least significant bytes. This crafts a 64 bits value that can go up to 18,446,744,073,709,551,615. That said, there are still two bytes (after the provider id) that will be 0, but at least it's a start to really use 64 bits. We have 4 bytes of entropy, now.

This very small change breaks many of the tests (mostly the *tests/basic.sh*, *tests/basic-ded-pool.sh*, *tests/basic-prio.sh*, *tests/basic-ded-pool-prio.sh*, *tests/timeout.sh*) and some unit tests, which either fail (*tests/unit-tests/margo-elasticity*) or hang (*tests/unit-tests/margo-comm-error*).

## Focusing on *tests/basic.sh*

This test uses *tests/margo-test-server.c*, *tests/margo-test-client.c*, and *tests/my-rpc.h*. The server will register 3 RPCs: `__shutdown__` (auto-registered by Margo when initialized), `my_rpc`, associated with `my_rpc_ult`, and `my_rpc_hang`, associated with `my_rpc_hang_ult`.

The client registers 2 RPCs: `__shutdown__`, and `my_rpc`. The client spawns 4 threads, each of which runs a "my_rpc" RPC.

The trace shows this from the server side:

```
[trace] Spawning ULT my_rpc_hang_ult for RPC __shutdown__ (handle = 0x5630821421c0)
[trace] Starting RPC __shutdown__ (handle = 0x5630821421c0)
[trace] Spawning ULT my_rpc_hang_ult for RPC __shutdown__ (handle = 0x563082148010)
[trace] Starting RPC __shutdown__ (handle = 0x563082148010)
[trace] Spawning ULT my_rpc_hang_ult for RPC __shutdown__ (handle = 0x563082142b60)
[trace] Starting RPC __shutdown__ (handle = 0x563082142b60)
[trace] Spawning ULT my_rpc_hang_ult for RPC __shutdown__ (handle = 0x56308214e2b0)
[trace] Starting RPC __shutdown__ (handle = 0x56308214e2b0)
```

A normal trace should have shown something like the following:

```
[trace] Spawning ULT my_rpc_ult for RPC my_rpc (handle = 0x5630821421c0)
[trace] Starting RPC my_rpc (handle = 0x5630821421c0)
```

In the actual trace, `my_rpc_hang_ult` is the name of the handler being invoked. `__shutdown__` is the name that is attached to the RPC id via `HG_Register_data`. So on the server, Mercury seems to have overridden the handlers: overriding __shutdown__ with my_rpc, then my_rpc with my_rpc_hang. Since Margo only registers data (including the name) if no data has been registered yet, the first name (__shutdown__) stuck.

This is a Mercury bug. I think Mercury is downcasting the hg_id_t into a 32 bit value somewhere when looking up data and handler. I have managed to reproduce it with a pure-Mercury code and submitted an issue: https://github.com/mercury-hpc/mercury/issues/646