### PR TITLE
cforward functions (forward with callback)

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -66,10 +66,10 @@ typedef void (*margo_finalize_callback_t)(void*);
  */
 typedef enum
 {
-    MARGO_RESPONSE_REQUEST,
-    MARGO_FORWARD_REQUEST,
-    MARGO_BULK_REQUEST,
-    MARGO_INVALID_REQUEST
+    MARGO_RESPONSE_REQUEST = 2,
+    MARGO_FORWARD_REQUEST  = 4,
+    MARGO_BULK_REQUEST     = 6,
+    MARGO_INVALID_REQUEST  = 8
 } margo_request_type;
 
 /**
@@ -1052,6 +1052,45 @@ margo_iforward(hg_handle_t handle, void* in_struct, margo_request* req)
 }
 
 /**
+ * @brief Same as margo_provider_iforward, but will invoke a user-provided
+ * callback upon completion of the RPC.
+ *
+ * @param provider_id Provider id.
+ * @param handle Handle of the RPC.
+ * @param in_struct Input arguments.
+ * @param on_complete Completion callback.
+ * @param uargs Arguments for the callback.
+ *
+ * @return 0 on success, hg_return_t values on error.
+ */
+hg_return_t margo_provider_cforward(uint16_t    provider_id,
+                                    hg_handle_t handle,
+                                    void*       in_struct,
+                                    void (*on_comblete)(void*, hg_return_t),
+                                    void* uargs);
+
+/**
+ * @brief Same as margo_iforward but will invoke a user-provided
+ * callback upon completion of the RPC.
+ *
+ * @param handle Handle of the RPC.
+ * @param in_struct Input arguments.
+ * @param on_complete Completion callback.
+ * @param uargs Arguments for the callback.
+ *
+ * @return 0 on success, hg_return_t values on error.
+ */
+static inline hg_return_t margo_cforward(hg_handle_t handle,
+                                         void*       in_struct,
+                                         void (*on_comblete)(void*,
+                                                             hg_return_t),
+                                         void* uargs)
+{
+    return margo_provider_cforward(MARGO_DEFAULT_PROVIDER_ID, handle, in_struct,
+                                   on_comblete, uargs);
+}
+
+/**
  * @brief Forward an RPC request to a remote provider with a user-defined
  * timeout.
  *
@@ -1116,6 +1155,50 @@ static inline hg_return_t margo_iforward_timed(hg_handle_t    handle,
 {
     return margo_provider_iforward_timed(MARGO_DEFAULT_PROVIDER_ID, handle,
                                          in_struct, timeout_ms, req);
+}
+
+/**
+ * @brief Same as margo_provider_iforward_timed, but will invoke a user-provided
+ * callback upon completion of the RPC or timeout.
+ *
+ * @param provider_id Provider id.
+ * @param handle Handle of the RPC.
+ * @param in_struct Input arguments.
+ * @param timeout_ms Timeout.
+ * @param on_complete Completion callback.
+ * @param uargs Arguments for the callback.
+ *
+ * @return 0 on success, hg_return_t values on error.
+ */
+hg_return_t margo_provider_cforward_timed(uint16_t    provider_id,
+                                          hg_handle_t handle,
+                                          void*       in_struct,
+                                          double      timeout_ms,
+                                          void (*on_comblete)(void*,
+                                                              hg_return_t),
+                                          void* uargs);
+
+/**
+ * @brief Same as margo_iforward_timed but will invoke a user-provided
+ * callback upon completion of the RPC or timeout.
+ *
+ * @param handle Handle of the RPC.
+ * @param in_struct Input arguments.
+ * @param on_complete Completion callback.
+ * @param uargs Arguments for the callback.
+ *
+ * @return 0 on success, hg_return_t values on error.
+ */
+static inline hg_return_t margo_cforward_timed(hg_handle_t handle,
+                                               void*       in_struct,
+                                               double      timeout_ms,
+                                               void (*on_comblete)(void*,
+                                                                   hg_return_t),
+                                               void* uargs)
+{
+    return margo_provider_cforward_timed(MARGO_DEFAULT_PROVIDER_ID, handle,
+                                         in_struct, timeout_ms, on_comblete,
+                                         uargs);
 }
 
 /**

--- a/include/margo.h
+++ b/include/margo.h
@@ -1055,6 +1055,13 @@ margo_iforward(hg_handle_t handle, void* in_struct, margo_request* req)
  * @brief Same as margo_provider_iforward, but will invoke a user-provided
  * callback upon completion of the RPC.
  *
+ * Note: the callback will be invoked in the ULT running the progress loop,
+ * hence it should not be long-lived or it will prevent Mercury from
+ * making network progress. This function should be used for lightweight
+ * operations (e.g. setting an eventual, changing the value of variable,
+ * notifying an ABT_cond, etc.). For more complex operations, it is
+ * recommended to wrap a call to margo_provider_forward inside a ULT.
+ *
  * @param provider_id Provider id.
  * @param handle Handle of the RPC.
  * @param in_struct Input arguments.
@@ -1072,6 +1079,9 @@ hg_return_t margo_provider_cforward(uint16_t    provider_id,
 /**
  * @brief Same as margo_iforward but will invoke a user-provided
  * callback upon completion of the RPC.
+ *
+ * Note: see note margo_provider_cforward comment regarding
+ * when to avoid using this function.
  *
  * @param handle Handle of the RPC.
  * @param in_struct Input arguments.
@@ -1161,6 +1171,9 @@ static inline hg_return_t margo_iforward_timed(hg_handle_t    handle,
  * @brief Same as margo_provider_iforward_timed, but will invoke a user-provided
  * callback upon completion of the RPC or timeout.
  *
+ * Note: see note margo_provider_cforward comment regarding
+ * when to avoid using this function.
+ *
  * @param provider_id Provider id.
  * @param handle Handle of the RPC.
  * @param in_struct Input arguments.
@@ -1181,6 +1194,9 @@ hg_return_t margo_provider_cforward_timed(uint16_t    provider_id,
 /**
  * @brief Same as margo_iforward_timed but will invoke a user-provided
  * callback upon completion of the RPC or timeout.
+ *
+ * Note: see note margo_provider_cforward comment regarding
+ * when to avoid using this function.
  *
  * @param handle Handle of the RPC.
  * @param in_struct Input arguments.

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -124,14 +124,29 @@ struct margo_instance {
 
 #define MARGO_RPC_POOL(mid) (mid)->abt.pools[mid->rpc_pool_idx].pool
 
+typedef enum margo_request_kind
+{
+    MARGO_REQ_EVENTUAL,
+    MARGO_REQ_CALLBACK
+} margo_request_kind;
+
 struct margo_request_struct {
-    margo_eventual_t     eventual;
-    hg_return_t          hret;
     margo_timer*         timer;
     margo_instance_id    mid;
     hg_handle_t          handle;
     margo_monitor_data_t monitor_data;
-    margo_request_type   type;
+    margo_request_type   type; // forward, respond, or bulk
+    margo_request_kind   kind; // callback or eventual
+    union {
+        struct {
+            margo_eventual_t ev;
+            hg_return_t      hret;
+        } eventual;
+        struct {
+            void (*cb)(void*, hg_return_t);
+            void* uargs;
+        } callback;
+    } u;
 };
 
 // Data registered to an RPC id with HG_Register_data


### PR DESCRIPTION
This PR introduces 4 new functions:
- margo_cforward
- margo_provider_cforward
- margo_cforward_timed
- margo_provider_cforward_timed

They work like the `margo_iforward` variants in that they immediately return to the caller, but instead of taking a pointer to a `margo_request` to set, they take a callback and argument to be called upon completion of the RPC (or timeout).

There is a unit test testing these functions.

Technically I could also add margo_crespond and margo_bulk_ctransfer families of functions, but cforward is the most useful. It will allow for instance to forward an RPC to N destinations and do something upon completion of each RPC without having to actively loop through an array of margo_requests.

Note: intuitively the margo_iforward functions should be rewritten to make use of the margo_cforward functions (with margo_cb being the callback to call and the request being the data to pass), but the other way around was simpler to implement.