### PR TITLE
use na+sm as transport for unit tests

### DIFF
--- a/tests/unit-tests/margo-forward.c
+++ b/tests/unit-tests/margo-forward.c
@@ -454,7 +454,7 @@ error:
     return MUNIT_FAIL;
 }
 
-static char* protocol_params[] = {"ofi+tcp", NULL};
+static char* protocol_params[] = {"na+sm", NULL};
 
 static MunitParameterEnum test_params[]
     = {{"protocol", protocol_params}, {NULL, NULL}};


### PR DESCRIPTION
change was prompted by interference from docker virtual network on some systems, but the built-in mercury sm protocol is more commonly available anyway and is already assumed present by other unit tests