### PR TITLE
clean up argobots profiling

### DIFF
--- a/examples/margo-example-server.c
+++ b/examples/margo-example-server.c
@@ -26,7 +26,8 @@ int main(int argc, char** argv)
     char                   addr_self_string[128];
     hg_size_t              addr_self_string_sz = 128;
     struct margo_init_info minfo               = {0};
-    char*                  starter_json        = "{\"output_dir\":\"/tmp\"}";
+    char*                  starter_json
+        = "{\"enable_abt_profiling\":true, \"output_dir\":\"/tmp\"}";
 
     if (argc != 2) {
         fprintf(stderr, "Usage: ./server <listen_addr>\n");

--- a/src/margo-abt-profiling.c
+++ b/src/margo-abt-profiling.c
@@ -104,8 +104,14 @@ static void margo_abt_profiling_dump_fp(margo_instance_id mid, FILE* outfile)
                         ABTX_PRINT_MODE_SUMMARY | ABTX_PRINT_MODE_FANCY);
         ABTX_prof_start(g_margo_abt_prof_context, g_margo_abt_prof_mode);
     } else {
-        ABTX_prof_print(g_margo_abt_prof_context, outfile,
-                        ABTX_PRINT_MODE_SUMMARY | ABTX_PRINT_MODE_FANCY);
+        fprintf(outfile,
+                "# Argobots profiling is not enabled. Consider doing one of "
+                "the following:\n");
+        fprintf(outfile,
+                "# - setting \"enable_abt_profiling\" to true in the margo "
+                "configuration\n");
+        fprintf(outfile,
+                "# - calling margo_start_abt_profiling() at runtime\n");
     }
 }
 

--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -56,6 +56,11 @@ char* margo_get_config_opt(margo_instance_id mid, int options)
     json_object_object_add_ex(root, "handle_cache_size",
                               json_object_new_uint64(mid->handle_cache_size),
                               flags);
+    // abt profiling
+    json_object_object_add_ex(
+        root, "enable_abt_profiling",
+        json_object_new_boolean(mid->abt_profiling_enabled), flags);
+
     // progress_pool and rpc_pool
     if (options & MARGO_CONFIG_USE_NAMES) {
         json_object_object_add_ex(

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -274,7 +274,7 @@ margo_instance_id margo_init_ext(const char*                   address,
     int handle_cache_size
         = json_object_object_get_int_or(config, "handle_cache_size", 32);
     int abt_profiling_enabled
-        = json_object_object_get_bool_or(config, "enable_abt_profiling", true);
+        = json_object_object_get_bool_or(config, "enable_abt_profiling", false);
 
     mid->abt_profiling_enabled = abt_profiling_enabled;
 
@@ -341,6 +341,10 @@ margo_instance_id margo_init_ext(const char*                   address,
 
         json_object_put(monitoring_config);
     }
+
+    /* start abt profiling if enabled */
+    if (mid->abt_profiling_enabled)
+        margo_start_abt_profiling(mid, ABTX_PROF_MODE_BASIC);
 
     mid->shutdown_rpc_id = MARGO_REGISTER(
         mid, "__shutdown__", void, margo_shutdown_out_t, remote_shutdown_ult);

--- a/tests/unit-tests/test-configs.json
+++ b/tests/unit-tests/test-configs.json
@@ -2,27 +2,27 @@
     "empty": {
         "pass": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/hide_external": {
         "pass": true,
         "hide_external": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks": {
         "pass": true,
         "input": {"argobots":{"abt_mem_max_num_stacks": 12}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":12,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":12,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks/abt_thread_stacksize/abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {"argobots":{"abt_mem_max_num_stacks": 12, "abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks/env": {
@@ -31,7 +31,7 @@
             "ABT_MEM_MAX_NUM_STACKS": "16"
         },
         "input": {"argobots":{"abt_mem_max_num_stacks": 12}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":16,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":16,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks_must_be_an_integer": {
@@ -42,7 +42,7 @@
     "abt_thread_stacksize": {
         "pass": true,
         "input": {"argobots":{"abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000000,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000000,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_thread_stacksize/env": {
@@ -51,7 +51,7 @@
             "ABT_THREAD_STACKSIZE": "2000002"
         },
         "input": {"argobots":{"abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000002,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000002,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_thread_stacksize_must_be_an_integer": {
@@ -62,27 +62,27 @@
     "use_progress_thread=true": {
         "pass": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "use_progress_thread=true/use_names": {
         "pass": true,
         "use_names": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":["__primary__"]},"name":"__primary__"},{"scheduler":{"type":"default","pools":["__pool_1__"]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":"__pool_1__","rpc_pool":"__primary__"}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":["__primary__"]},"name":"__primary__"},{"scheduler":{"type":"default","pools":["__pool_1__"]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":"__pool_1__","rpc_pool":"__primary__"}
     },
 
     "use_progress_thread=false": {
         "pass": true,
         "input": {"use_progress_thread": false},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/with_abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/with_abt_init/hide_external": {
@@ -90,21 +90,21 @@
         "abt_init": true,
         "hide_external": true,
         "input": {},
-        "output": {"argobots":{"pools":[],"xstreams":[],"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[],"xstreams":[],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "use_progress_thread=true/with_abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "use_progress_thread=false/with_abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {"use_progress_thread": false},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "use_progress_thead=string": {
@@ -115,25 +115,25 @@
     "rpc_thread_count=-1": {
         "pass": true,
         "input": {"rpc_thread_count": -1},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "rpc_thread_count=0": {
         "pass": true,
         "input": {"rpc_thread_count": 0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "rpc_thread_count=1": {
         "pass": true,
         "input": {"rpc_thread_count": 1},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "rpc_thread_count=2": {
         "pass": true,
         "input": {"rpc_thread_count": 2},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "rpc_thread_count=string": {
@@ -144,31 +144,31 @@
     "rpc_thread_count=-1/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": -1, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "rpc_thread_count=0/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 0, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_thread_count=1/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 1, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
     },
 
     "rpc_thread_count=2/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 2, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_2__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_3__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_2__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_3__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
     },
 
     "valid_pool_kinds_and_access": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"fifo_pool","kind":"fifo","access":"private"},{"name":"fifo_wait_pool","kind":"fifo_wait","access":"mpmc"},{"name":"prio_wait_pool","kind":"prio_wait","access":"spsc"},{"name":"fifo_pool_2","kind":"fifo","access":"mpsc"},{"name":"fifo_pool_3","kind":"fifo","access":"spmc"}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"fifo_pool","access":"private"},{"kind":"fifo_wait","name":"fifo_wait_pool","access":"mpmc"},{"kind":"prio_wait","name":"prio_wait_pool","access":"spsc"},{"kind":"fifo","name":"fifo_pool_2","access":"mpsc"},{"kind":"fifo","name":"fifo_pool_3","access":"spmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[5]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":5,"rpc_pool":5}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"fifo_pool","access":"private"},{"kind":"fifo_wait","name":"fifo_wait_pool","access":"mpmc"},{"kind":"prio_wait","name":"prio_wait_pool","access":"spsc"},{"kind":"fifo","name":"fifo_pool_2","access":"mpsc"},{"kind":"fifo","name":"fifo_pool_3","access":"spmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[5]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":5,"rpc_pool":5}
     },
 
     "argobots_should_be_an_object": {
@@ -289,7 +289,7 @@
     "xstreams_cpubind": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"cpubind":0,"scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "xstreams_cpubind_should_be_an_integer": {
@@ -300,7 +300,7 @@
     "xstreams_affinity": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"affinity":[0,1],"scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "xstreams_affinity_should_be_an_array": {
@@ -361,19 +361,19 @@
     "progress_pool_string": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"my_pool"}],"xstreams":[{"scheduler":{"pools":["my_pool"]}}]},"progress_pool":"my_pool"},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "progress_pool_integer": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"progress_pool":0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "use_progress_thread_is_ignored": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"progress_pool":0, "use_progress_thread":false},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "progress_pool_should_be_string_or_integer": {
@@ -394,19 +394,19 @@
     "rpc_pool_string": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"my_pool"}],"xstreams":[{"scheduler":{"pools":["my_pool"]}}]},"rpc_pool":"my_pool"},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_pool_integer": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"rpc_pool":0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_thread_count_is_ignored": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"rpc_pool":0,"rpc_thread_count":4},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_pool_should_be_string_or_integer": {
@@ -427,13 +427,13 @@
     "primary_pool": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "primary_xstream": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}],"xstreams":[{"name":"__primary__","scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "primary_xstream_without_scheduler": {

--- a/tests/unit-tests/test-configs.json
+++ b/tests/unit-tests/test-configs.json
@@ -457,4 +457,10 @@
         "abt_init": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}],"xstreams":[{"name":"__primary__","scheduler":{"pools":[0]}}]}}
     },
+
+    "enable_abt_profiling": {
+        "pass": true,
+        "input": {"enable_abt_profiling": true},
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":true,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+    }
 }


### PR DESCRIPTION
Fixes #245 

- disable abt profiling by default
- start profiler if requested by config
- do not attempt to print profile statistics if profiler not started