### PR TITLE
use "basic_wait" as the default scheduler

### DIFF
--- a/src/margo-abt-config.c
+++ b/src/margo-abt-config.c
@@ -292,8 +292,8 @@ bool __margo_abt_sched_init_from_json(const json_object_t* jsched,
                                       margo_abt_sched_t*   s,
                                       ABT_sched*           abt_sched)
 {
-    s->type
-        = strdup(json_object_object_get_string_or(jsched, "type", "default"));
+    s->type = strdup(
+        json_object_object_get_string_or(jsched, "type", "basic_wait"));
 
     ABT_sched_predef sched_predef = ABT_SCHED_DEFAULT;
     if (s->type) {

--- a/tests/unit-tests/test-configs.json
+++ b/tests/unit-tests/test-configs.json
@@ -2,20 +2,20 @@
     "empty": {
         "pass": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/hide_external": {
         "pass": true,
         "hide_external": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks": {
         "pass": true,
         "input": {"argobots":{"abt_mem_max_num_stacks": 12}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":12,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":12,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks/abt_thread_stacksize/abt_init": {
@@ -31,7 +31,7 @@
             "ABT_MEM_MAX_NUM_STACKS": "16"
         },
         "input": {"argobots":{"abt_mem_max_num_stacks": 12}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":16,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":16,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks_must_be_an_integer": {
@@ -42,7 +42,7 @@
     "abt_thread_stacksize": {
         "pass": true,
         "input": {"argobots":{"abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000000,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000000,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_thread_stacksize/env": {
@@ -51,7 +51,7 @@
             "ABT_THREAD_STACKSIZE": "2000002"
         },
         "input": {"argobots":{"abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000002,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000002,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_thread_stacksize_must_be_an_integer": {
@@ -62,20 +62,20 @@
     "use_progress_thread=true": {
         "pass": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "use_progress_thread=true/use_names": {
         "pass": true,
         "use_names": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":["__primary__"]},"name":"__primary__"},{"scheduler":{"type":"default","pools":["__pool_1__"]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":"__pool_1__","rpc_pool":"__primary__"}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":["__primary__"]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":["__pool_1__"]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":"__pool_1__","rpc_pool":"__primary__"}
     },
 
     "use_progress_thread=false": {
         "pass": true,
         "input": {"use_progress_thread": false},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/with_abt_init": {
@@ -97,7 +97,7 @@
         "pass": true,
         "abt_init": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "use_progress_thread=false/with_abt_init": {
@@ -115,25 +115,25 @@
     "rpc_thread_count=-1": {
         "pass": true,
         "input": {"rpc_thread_count": -1},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "rpc_thread_count=0": {
         "pass": true,
         "input": {"rpc_thread_count": 0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "rpc_thread_count=1": {
         "pass": true,
         "input": {"rpc_thread_count": 1},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "rpc_thread_count=2": {
         "pass": true,
         "input": {"rpc_thread_count": 2},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "rpc_thread_count=string": {
@@ -144,31 +144,31 @@
     "rpc_thread_count=-1/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": -1, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "rpc_thread_count=0/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 0, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_thread_count=1/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 1, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
     },
 
     "rpc_thread_count=2/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 2, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"default","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_2__"},{"scheduler":{"type":"default","pools":[2]},"name":"__xstream_3__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_2__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_3__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
     },
 
     "valid_pool_kinds_and_access": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"fifo_pool","kind":"fifo","access":"private"},{"name":"fifo_wait_pool","kind":"fifo_wait","access":"mpmc"},{"name":"prio_wait_pool","kind":"prio_wait","access":"spsc"},{"name":"fifo_pool_2","kind":"fifo","access":"mpsc"},{"name":"fifo_pool_3","kind":"fifo","access":"spmc"}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"fifo_pool","access":"private"},{"kind":"fifo_wait","name":"fifo_wait_pool","access":"mpmc"},{"kind":"prio_wait","name":"prio_wait_pool","access":"spsc"},{"kind":"fifo","name":"fifo_pool_2","access":"mpsc"},{"kind":"fifo","name":"fifo_pool_3","access":"spmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[5]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":5,"rpc_pool":5}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"fifo_pool","access":"private"},{"kind":"fifo_wait","name":"fifo_wait_pool","access":"mpmc"},{"kind":"prio_wait","name":"prio_wait_pool","access":"spsc"},{"kind":"fifo","name":"fifo_pool_2","access":"mpsc"},{"kind":"fifo","name":"fifo_pool_3","access":"spmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[5]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":5,"rpc_pool":5}
     },
 
     "argobots_should_be_an_object": {
@@ -289,7 +289,7 @@
     "xstreams_cpubind": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"cpubind":0,"scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "xstreams_cpubind_should_be_an_integer": {
@@ -300,7 +300,7 @@
     "xstreams_affinity": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"affinity":[0,1],"scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "xstreams_affinity_should_be_an_array": {
@@ -361,19 +361,19 @@
     "progress_pool_string": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"my_pool"}],"xstreams":[{"scheduler":{"pools":["my_pool"]}}]},"progress_pool":"my_pool"},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "progress_pool_integer": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"progress_pool":0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "use_progress_thread_is_ignored": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"progress_pool":0, "use_progress_thread":false},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "progress_pool_should_be_string_or_integer": {
@@ -394,19 +394,19 @@
     "rpc_pool_string": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"my_pool"}],"xstreams":[{"scheduler":{"pools":["my_pool"]}}]},"rpc_pool":"my_pool"},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_pool_integer": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"rpc_pool":0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_thread_count_is_ignored": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"rpc_pool":0,"rpc_thread_count":4},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"default","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_pool_should_be_string_or_integer": {
@@ -427,13 +427,13 @@
     "primary_pool": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "primary_xstream": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}],"xstreams":[{"name":"__primary__","scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "primary_xstream_without_scheduler": {
@@ -461,6 +461,6 @@
     "enable_abt_profiling": {
         "pass": true,
         "input": {"enable_abt_profiling": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"default","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":true,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":true,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     }
 }


### PR DESCRIPTION
- the "default" scheduler refers to the Argobots default, which causes idle execution streams to spin looking for new work units
- the "basic_wait" scheduler is the one that pairs with the "fifo_wait" pool type that we are using by default and will suspend until work is available

Fixes #248.

Once this is validated and merged then I'll update the scheduling unit test to fail if CPU usage is too high.