### PR TITLE
Added a margo-version.h header generated

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,14 +23,15 @@ include_HEADERS = \
  include/margo-util.h \
  include/margo-bulk-util.h \
  include/margo-timer.h \
- include/margo-monitoring.h
+ include/margo-monitoring.h \
+ include/margo-version.h
 
 TESTS_ENVIRONMENT =
 
 EXTRA_DIST += \
  prepare.sh 
 
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
 
 AM_CFLAGS =
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,23 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
+
+# IMPORTANT: when editing the version  number, edit both the
+# MARGO_VERSION_ variables and the argument provided to AC_INIT
 AC_INIT([margo], [0.13.1], [],[],[])
+
+MARGO_VERSION_MAJOR=0
+MARGO_VERSION_MINOR=13
+MARGO_VERSION_PATCH=1
+MARGO_VERSION="$MARGO_VERSION_MAJOR.$MARGO_VERSION_MINOR.$MARGO_VERSION_PATCH"
+MARGO_VERSION_NUM=$((MARGO_VERSION_MAJOR*100000+MARGO_VERSION_MINOR*100+MARGO_VERSION_PATCH))
+
+AC_SUBST([MARGO_VERSION], ["$MARGO_VERSION"])
+AC_SUBST([MARGO_VERSION_MAJOR], ["$MARGO_VERSION_MAJOR"])
+AC_SUBST([MARGO_VERSION_MINOR], ["$MARGO_VERSION_MINOR"])
+AC_SUBST([MARGO_VERSION_PATCH], ["$MARGO_VERSION_PATCH"])
+AC_SUBST([MARGO_VERSION_NUM], ["$MARGO_VERSION_NUM"])
+
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
 
@@ -183,5 +199,5 @@ fi
 
 AC_CONFIG_LINKS([tests/unit-tests/test-configs.json:tests/unit-tests/test-configs.json])
 
-AC_CONFIG_FILES([Makefile maint/margo.pc])
+AC_CONFIG_FILES([Makefile maint/margo.pc include/margo-version.h])
 AC_OUTPUT

--- a/include/margo-version.h.in
+++ b/include/margo-version.h.in
@@ -1,0 +1,17 @@
+/**
+ * @file margo-version.h
+ *
+ * (C) The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#ifndef __MARGO_VERSION
+#define __MARGO_VERSION
+
+#define MARGO_VERSION       @MARGO_VERSION@
+#define MARGO_VERSION_MAJOR @MARGO_VERSION_MAJOR@
+#define MARGO_VERSION_MINOR @MARGO_VERSION_MINOR@
+#define MARGO_VERSION_PATCH @MARGO_VERSION_PATCH@
+#define MARGO_VERSION_NUM   @MARGO_VERSION_NUM@
+
+#endif /* __MARGO_VERSION */

--- a/include/margo.h
+++ b/include/margo.h
@@ -18,6 +18,7 @@ extern "C" {
 #include <mercury_bulk.h>
 #include <mercury_macros.h>
 #include <abt.h>
+#include <margo-version.h>
 #include <margo-logging.h>
 #include <margo-monitoring.h>
 #include <margo-config.h>


### PR DESCRIPTION
Adds a margo-version.h header generated from the version found in configure.ac. This is needed if we want libraries built on top of Margo to rely on different functions depending on their availability.

@carns Can you double-check that I haven't done anything stupid?