### PR TITLE
Added functions to disable input and output headers

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -801,6 +801,34 @@ hg_return_t margo_registered_disabled_response(margo_instance_id mid,
                                                int*              disabled_flag);
 
 /**
+ * @brief Disable internal input header for a given RPC ID.
+ * This function can be used to allow Margo RPCs to be used by Mercury-based
+ * codes: since Margo adds a header to RPC inputs, this header needs to be
+ * disabled for a Mercury-based program to call this RPC.
+ *
+ * @param [in] mid          Margo instance.
+ * @param [in] id           Registered RPC ID.
+ *
+ * @return HG_SUCCESS or corresponding HG error code.
+ */
+hg_return_t margo_registered_disable_input_header(margo_instance_id mid,
+                                                  hg_id_t           id);
+
+/**
+ * @brief Disable internal output header for a given RPC ID.
+ * This function can be used to allow Margo RPCs to be used by Mercury-based
+ * codes: since Margo adds a header to RPC outputs, this header needs to be
+ * disabled for a Mercury-based program to call this RPC.
+ *
+ * @param [in] mid          Margo instance.
+ * @param [in] id           Registered RPC ID.
+ *
+ * @return HG_SUCCESS or corresponding HG error code.
+ */
+hg_return_t margo_registered_disable_output_header(margo_instance_id mid,
+                                                   hg_id_t           id);
+
+/**
  * @brief Lookup an addr from a peer address/name.
  *
  * @param [in] name     Lookup name.

--- a/spack.yaml
+++ b/spack.yaml
@@ -10,7 +10,6 @@ spack:
   - mercury~boostsys ^libfabric fabrics=tcp,rxm
   concretizer:
     unify: true
-    reuse: false
   modules:
     prefix_inspections:
       lib: [LD_LIBRARY_PATH]

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -154,8 +154,10 @@ struct margo_rpc_data {
     margo_instance_id mid;
     _Atomic(ABT_pool) pool;
     char*        rpc_name;
-    hg_proc_cb_t in_proc_cb;  /* user-provided input proc */
-    hg_proc_cb_t out_proc_cb; /* user-provided output proc */
+    hg_proc_cb_t in_proc_cb;         /* user-provided input proc */
+    hg_proc_cb_t out_proc_cb;        /* user-provided output proc */
+    bool         disable_in_header;  /* whether to disable input header */
+    bool         disable_out_header; /* whether to disable output header */
     void*        user_data;
     void (*user_free_callback)(void*);
 };
@@ -164,10 +166,12 @@ struct margo_rpc_data {
 struct margo_handle_data {
     margo_instance_id mid;
     ABT_pool          pool;
-    const char*       rpc_name; /* note: same pointer as in margo_rpc_data,
-                                   not the responsibility of the handle to free it */
-    hg_proc_cb_t in_proc_cb;    /* user-provided input proc */
-    hg_proc_cb_t out_proc_cb;   /* user-provided output proc */
+    const char*       rpc_name;      /* note: same pointer as in margo_rpc_data,
+                                        not the responsibility of the handle to free it */
+    hg_proc_cb_t in_proc_cb;         /* user-provided input proc */
+    hg_proc_cb_t out_proc_cb;        /* user-provided output proc */
+    bool         disable_in_header;  /* whether to disable input header */
+    bool         disable_out_header; /* whether to disable output header */
     void*        user_data;
     void (*user_free_callback)(void*);
     margo_monitor_data_t monitor_data;


### PR DESCRIPTION
This PR adds two functions, `margo_registered_disable_input/output_header`, which disable the header that margo adds in the serialization path to all inputs and outputs. This feature was requested by @marcvef, who has a Mercury-based client interacting with a Margo-based server. In this situation, because Margo adds / is expecting those headers, this causes problems when Mercury sends an RPC without one, or receives a response that has one.

Currently the input header is used to carry information about a possible parent RPC id from which the current RPC is called. This information is used to track callpath. Disabling it will cause the monitoring subsystem to believe that the RPC has no parent, even when it does. It's not much of a problem.

The output header is a bit more important, as it carries a Mercury error code that is used to tell the client that something went wrong in the server that prevented the handler from even starting (e.g. ABT_thread_create failed, or the RPC handler is NULL, etc.). These errors are rare and result from either an incorrect program (e.g. calling an RPC handler set to NULL) or something like a memory issue (e.g. ABT_thread_create failed to allocate a stack). Hitting those problems used to result in the server ignoring the RPC (since it couldn't tell the client what went wrong) and the client hanging, waiting for a response. Here if the output header is disabled, any such error now becomes undefined behavior.

Disabling these headers is not a great idea in general, but it's the only way I see to make Mercury and Margo send RPCs to each other. The better solution would be to not have a client library that uses Mercury, and rely on Margo everywhere. I don't exclude that these functions will disappear from the API if we ever need those headers to carry important information (I kind of feel like the output header is actually pretty important already).