### PR TITLE
margo-hg-shim library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ bin_SCRIPTS =
 noinst_PROGRAMS =
 noinst_HEADERS =
 TESTS =
-XFAIL_TESTS = 
+XFAIL_TESTS =
 check_PROGRAMS =
 EXTRA_PROGRAMS =
 CLEANFILES = $(bin_SCRIPTS)
@@ -24,12 +24,13 @@ include_HEADERS = \
  include/margo-bulk-util.h \
  include/margo-timer.h \
  include/margo-monitoring.h \
- include/margo-version.h
+ include/margo-version.h \
+ include/margo-hg-shim.h
 
 TESTS_ENVIRONMENT =
 
 EXTRA_DIST += \
- prepare.sh 
+ prepare.sh
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
 
@@ -39,13 +40,14 @@ AM_LIBS =
 
 AM_CXXFLAGS = $(AM_CFLAGS)
 
-lib_LTLIBRARIES = src/libmargo.la
+lib_LTLIBRARIES = src/libmargo.la src/libmargo-hg-shim.la
 src_libmargo_la_SOURCES =
+src_libmargo_hg_shim_la_SOURCES =
 
-LDADD = src/libmargo.la
+LDADD = src/libmargo.la src/libmargo-hg-shim.la
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = maint/margo.pc
+pkgconfig_DATA = maint/margo.pc maint/margo-hg-shim.pc
 
 include Make.rules
 

--- a/configure.ac
+++ b/configure.ac
@@ -199,5 +199,5 @@ fi
 
 AC_CONFIG_LINKS([tests/unit-tests/test-configs.json:tests/unit-tests/test-configs.json])
 
-AC_CONFIG_FILES([Makefile maint/margo.pc include/margo-version.h])
+AC_CONFIG_FILES([Makefile maint/margo.pc maint/margo-hg-shim.pc include/margo-version.h])
 AC_OUTPUT

--- a/include/margo-hg-shim.h
+++ b/include/margo-hg-shim.h
@@ -1,0 +1,96 @@
+/**
+ * @file margo-hg-shim.h
+ *
+ * (C) 2023 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#ifndef __MARGO_HG_SHIM_H
+#define __MARGO_HG_SHIM_H
+
+#include <mercury.h>
+#include <mercury_proc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This file provides functions to enable a purely Mercury-based program
+ * and Margo-based program to work together properly. Margo adds a header
+ * to the input and output serialization path, hence if a program registers
+ * an RPC using Mercury (e.g. with HG_Register_name) while another program
+ * registers the same RPC using Margo (e.g. with margo_register), Margo will
+ * not find the header when Mercury sends the RPC and Mercury will find a
+ * header when it is not expecting one. Margo also computes RPC ids differently
+ * than Mercury from an RPC name.
+ *
+ * To solve this problem, please replace Mercury functions in your Mercury-based
+ * code as follows, and link your Mercury code against libmargo-hg-shim.so.
+ *
+ * - HG_Register_name => HG_Register_name_for_margo
+ * - HG_Get_input     => HG_Get_input_from_margo
+ * - HG_Free_input    => HG_Free_input_from_margo
+ * - HG_Get_output    => HG_Get_output_from_margo
+ * - HG_Free_output   => HG_Free_output_from_margo
+ * - HG_Forward       => HG_Forward_to_margo
+ * - HG_Respond       => HG_Respond_to_margo
+ *
+ * HG_Register does not have an equivalent and should not be used.
+ * The rest of the Mercury functions can remain unchanged.
+ *
+ * Note that using the above functions will still make it possible for your
+ * Mercury program to send RPC to / receive RPC from another Mercury program
+ * as long as this program also uses the above functions.
+ *
+ * Note that contrary to Mercury, where serialization functions are provided
+ * in calls to HG_Register and HG_Register_name, in these new variants, the
+ * serialization function is provided when calling HG_Forward, HG_Respond,
+ * HG_Get_input/output and HG_Free_input/output. Hence, make sure you provide
+ * the correct proc function pointer to all these calls. Additionally, the
+ * HG_Registered_proc_cb is no longer relevant since it will return proc
+ * functions that are internal to Margo.
+ *
+ * Important: these shim functions do not support provider IDs. Margo codes
+ * should register their RPC with a provider ID of MARGO_DEFAULT_PROVIDER_ID
+ * (or simply use MARGO_REGISTER/margo_register_name instead of
+ * MARGO_REGISTER_PROVIDER/margo_provider_register_name).
+ */
+
+hg_id_t HG_Register_name_for_margo(hg_class_t* hg_class,
+                                   const char* func_name,
+                                   hg_rpc_cb_t rpc_cb);
+
+hg_return_t HG_Forward_to_margo(hg_handle_t  handle,
+                                hg_cb_t      cb,
+                                void*        args,
+                                hg_proc_cb_t proc_in,
+                                void*        in_struct);
+
+hg_return_t HG_Respond_to_margo(hg_handle_t  handle,
+                                hg_cb_t      cb,
+                                void*        args,
+                                hg_proc_cb_t proc_out,
+                                void*        out_struct);
+
+hg_return_t HG_Get_input_from_margo(hg_handle_t  handle,
+                                    hg_proc_cb_t proc_in,
+                                    void*        in_struct);
+
+hg_return_t HG_Free_input_from_margo(hg_handle_t  handle,
+                                     hg_proc_cb_t proc_in,
+                                     void*        in_struct);
+
+hg_return_t HG_Get_output_from_margo(hg_handle_t  handle,
+                                     hg_proc_cb_t proc_out,
+                                     void*        out_struct);
+
+hg_return_t HG_Free_output_from_margo(hg_handle_t  handle,
+                                      hg_proc_cb_t proc_out,
+                                      void*        out_struct);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/maint/margo-hg-shim.pc.in
+++ b/maint/margo-hg-shim.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: margo-hg-shim
+Description: Margo/Mercury compatibility library
+Version: @PACKAGE_VERSION@
+URL: https://github.com/mochi-hpc/mochi-margo/
+Requires: mercury
+Libs: -L${libdir} -lmargo-hg-shim
+Cflags: -I${includedir}

--- a/maint/margo.pc.in
+++ b/maint/margo.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: margo
 Description: Argobots bindings for Mercury RPC library
 Version: @PACKAGE_VERSION@
-URL: https://xgitlab.cels.anl.gov/sds/margo
+URL: https://github.com/mochi-hpc/mochi-margo/
 Requires: @PC_REQUIRES@
 Libs: -L${libdir} -lmargo @PTHREAD_LIBS@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@

--- a/src/Makefile.subdir
+++ b/src/Makefile.subdir
@@ -31,6 +31,9 @@ src_libmargo_la_SOURCES += \
  src/margo-monitoring.c \
  src/margo-default-monitoring.c
 
+src_libmargo_hg_shim_la_SOURCES += \
+ src/margo-hg-shim.c
+
 bin_PROGRAMS += src/margo-info
 
 src_margo_info_SOURCES = src/margo-info.c

--- a/src/margo-hg-shim.c
+++ b/src/margo-hg-shim.c
@@ -1,0 +1,110 @@
+/**
+ * @file margo-hg-shim.c
+ *
+ * (C) 2023 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#include <mercury.h>
+#include "margo-serialization.h"
+#include "margo-id.h"
+#include "margo-hg-shim.h"
+
+static inline hg_return_t margo_hg_shim_forward_proc(hg_proc_t proc, void* args)
+{
+    margo_forward_proc_args_t sargs = (margo_forward_proc_args_t)args;
+    hg_return_t               hret  = HG_SUCCESS;
+
+    hret = hg_proc_memcpy(proc, (void*)(&sargs->header), sizeof(sargs->header));
+    if (hret != HG_SUCCESS) return hret;
+    if (!(sargs && sargs->user_cb)) return HG_SUCCESS;
+    return sargs->user_cb(proc, sargs->user_args);
+}
+
+static inline hg_return_t margo_hg_shim_respond_proc(hg_proc_t proc, void* args)
+{
+    margo_respond_proc_args_t sargs = (margo_respond_proc_args_t)args;
+    hg_return_t               hret  = HG_SUCCESS;
+
+    hret = hg_proc_memcpy(proc, (void*)(&sargs->header), sizeof(sargs->header));
+    if (hret != HG_SUCCESS) return hret;
+    if (!(sargs && sargs->user_cb)) return HG_SUCCESS;
+    return sargs->user_cb(proc, sargs->user_args);
+}
+
+hg_id_t HG_Register_name_for_margo(hg_class_t* hg_class,
+                                   const char* func_name,
+                                   hg_rpc_cb_t rpc_cb)
+{
+    hg_id_t     id  = gen_id(func_name, MARGO_DEFAULT_PROVIDER_ID);
+    hg_return_t ret = HG_Register(hg_class, id, margo_hg_shim_forward_proc,
+                                  margo_hg_shim_respond_proc, rpc_cb);
+    if (ret == HG_SUCCESS)
+        return id;
+    else
+        return 0;
+}
+
+hg_return_t HG_Forward_to_margo(hg_handle_t  handle,
+                                hg_cb_t      cb,
+                                void*        args,
+                                hg_proc_cb_t proc_in,
+                                void*        in_struct)
+{
+    struct margo_forward_proc_args in_args = {0};
+    in_args.user_args                      = in_struct;
+    in_args.user_cb                        = proc_in;
+    return HG_Forward(handle, cb, args, &in_args);
+}
+
+hg_return_t HG_Respond_to_margo(hg_handle_t  handle,
+                                hg_cb_t      cb,
+                                void*        args,
+                                hg_proc_cb_t proc_out,
+                                void*        out_struct)
+{
+    struct margo_respond_proc_args out_args = {0};
+    out_args.user_args                      = out_struct;
+    out_args.user_cb                        = proc_out;
+    return HG_Respond(handle, cb, args, &out_args);
+}
+
+hg_return_t HG_Get_input_from_margo(hg_handle_t  handle,
+                                    hg_proc_cb_t proc_in,
+                                    void*        in_struct)
+{
+    struct margo_forward_proc_args in_args = {0};
+    in_args.user_args                      = in_struct;
+    in_args.user_cb                        = proc_in;
+    return HG_Get_input(handle, &in_args);
+}
+
+hg_return_t HG_Free_input_from_margo(hg_handle_t  handle,
+                                     hg_proc_cb_t proc_in,
+                                     void*        in_struct)
+{
+    struct margo_forward_proc_args in_args = {0};
+    in_args.user_args                      = in_struct;
+    in_args.user_cb                        = proc_in;
+    return HG_Free_input(handle, &in_args);
+}
+
+hg_return_t HG_Get_output_from_margo(hg_handle_t  handle,
+                                     hg_proc_cb_t proc_out,
+                                     void*        out_struct)
+{
+    struct margo_respond_proc_args out_args = {0};
+    out_args.user_args                      = out_struct;
+    out_args.user_cb                        = proc_out;
+    return HG_Get_output(handle, &out_args);
+}
+
+hg_return_t HG_Free_output_from_margo(hg_handle_t  handle,
+                                      hg_proc_cb_t proc_out,
+                                      void*        out_struct)
+{
+    struct margo_respond_proc_args out_args = {0};
+    out_args.user_args                      = out_struct;
+    out_args.user_cb                        = proc_out;
+    return HG_Free_output(handle, &out_args);
+}


### PR DESCRIPTION
This PR adds a `margo-hg-shim` library, with a `margo-hg-shim.h` header and a `margo-hg-shim.pc` file to find them. The purpose of this library is to provide a set of `HG_*` functions meant for a Mercury-based code to interact with a Margo-based code.

This solves the same problem as https://github.com/mochi-hpc/mochi-margo/pull/256 but in a cleaner way from Margo's perspective (making Mercury aware of the Margo headers and way of generating the RPC id instead of disabling the headers on Margo's side).

@marcvef can you give it a try? the tests/unit-tests/margo-forward.c file has an example of using these functions.