### PR TITLE
Add refcount to margo instance

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -384,10 +384,57 @@ void margo_wait_for_finalize(margo_instance_id mid);
 void margo_finalize_and_wait(margo_instance_id mid);
 
 /**
+ * @brief Increments the internal reference counter of the instance.
+ * By default a created margo_instance_id has a refcount of 0 and will
+ * be automatically freed when margo_finalize is called. Increasing
+ * the refcount will prevent this free operation. The instance will
+ * still be finalized by margo_finalize but its memory will remain
+ * valid until margo_instance_release decreases the refcount back to 0.
+ *
+ * @param mid Margo instance ID
+ *
+ * @return HG_SUCCESS or other Mercury error code.
+ */
+hg_return_t margo_instance_ref_incr(margo_instance_id mid);
+
+/**
+ * @brief Decrements the internal refcount of the instance.
+ * If the refcount reaches 0, this will (1) call margo_finalize
+ * if the instance hasn't been finalized yet, and (2) free the
+ * instance's memory.
+ *
+ * @param[in] mid Margo instance ID
+ *
+ * @return HG_SUCCESS or other Mercury error code.
+ */
+hg_return_t margo_instance_release(margo_instance_id mid);
+
+/**
+ * @brief Check whether the instance has been finalized. Note that this
+ * function is meant to be used by codes that rely on margo_instance_ref_incr
+ * and margo_instance_release to keep track of ownership of the instance.
+ *
+ * @param[in] mid Margo instance ID
+ *
+ * @return HG_SUCCESS or other Mercury error code.
+ */
+hg_return_t margo_instance_is_finalized(margo_instance_id mid, bool* flag);
+
+/**
+ * @brief Get the internal refcount of the instance.
+ *
+ * @param[in] mid Margo instance ID
+ * @param[out] refcount Refcount
+ *
+ * @return HG_SUCCESS or other Mercury error code.
+ */
+hg_return_t margo_instance_ref_count(margo_instance_id mid, unsigned* refcount);
+
+/**
  * @brief Checks whether a Margo instance we initialized is a server
  * (i.e., listening for incoming RPC requests).
  *
- * @param [in] mid Margo instance/
+ * @param [in] mid Margo instance
  *
  * @return true if listening or false if not, or not a valid margo instance.
  */

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -276,6 +276,8 @@ margo_instance_id margo_init_ext(const char*                   address,
     int abt_profiling_enabled
         = json_object_object_get_bool_or(config, "enable_abt_profiling", false);
 
+    mid->refcount = 0;
+
     mid->abt_profiling_enabled = abt_profiling_enabled;
 
     mid->hg      = hg;
@@ -292,7 +294,7 @@ margo_instance_id margo_init_ext(const char*                   address,
     mid->num_registered_rpcs = 0;
     mid->registered_rpcs     = NULL;
 
-    mid->finalize_flag     = 0;
+    mid->finalize_flag     = false;
     mid->finalize_refcount = 0;
     ABT_mutex_create(&mid->finalize_mutex);
     ABT_cond_create(&mid->finalize_cond);

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -53,6 +53,8 @@ struct margo_registered_rpc {
 };
 
 struct margo_instance {
+    /* Refcount */
+    _Atomic unsigned refcount;
 
     /* Argobots environment */
     struct margo_abt abt;
@@ -76,7 +78,7 @@ struct margo_instance {
     struct margo_registered_rpc* registered_rpcs;
 
     /* control logic for callers waiting on margo to be finalized */
-    int                       finalize_flag;
+    _Atomic bool              finalize_flag;
     _Atomic int               finalize_refcount;
     ABT_mutex                 finalize_mutex;
     ABT_cond                  finalize_cond;


### PR DESCRIPTION
This PR is a response to issue https://github.com/mochi-hpc/mochi-margo/issues/260
@carns Could you review it?

Note: it does not change the semantics of any program written so far, nor is the use of the new functions required. They are just convenient in particular in C++ codes that want to rely on reference counting for memory management.

This PR comes with two extra suggestions:
- Should we add a check at the beginning of all the margo functions that the instance has not been finalized, or is it the responsibility of the user to ensure that they don't call functions on a finalized instance? (the latter doesn't differ from what is done right now)
- Should we move ABT_finalize to when the instance is freed, as opposed to finalized, so it gives a chance to codes that rely on this refcounting to keep Argobots objects around until the instance is actually freed?