### PR TITLE
Add implementation of "earliest_first" pool

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -10,7 +10,7 @@ spack:
   - mercury~boostsys ^libfabric fabrics=tcp,rxm
   concretizer:
     unify: true
-    reuse: false
+    reuse: true
   modules:
     prefix_inspections:
       lib: [LD_LIBRARY_PATH]

--- a/src/Makefile.subdir
+++ b/src/Makefile.subdir
@@ -7,6 +7,7 @@ noinst_HEADERS += src/margo-abt-macros.h \
                   src/margo-instance.h\
                   src/margo-macros.h\
                   src/margo-prio-pool.h\
+                  src/margo-efirst-pool.h\
                   src/margo-timer-private.h \
                   src/margo-monitoring-internal.h \
                   src/margo-abt-config.h \
@@ -28,6 +29,7 @@ src_libmargo_la_SOURCES += \
  src/margo-timer.c \
  src/margo-util.c \
  src/margo-prio-pool.c \
+ src/margo-efirst-pool.c \
  src/margo-monitoring.c \
  src/margo-default-monitoring.c
 

--- a/src/margo-abt-config.c
+++ b/src/margo-abt-config.c
@@ -37,7 +37,7 @@ bool __margo_abt_pool_validate_json(const json_object_t* jpool,
     json_object_t* jkind = json_object_object_get(jpool, "kind");
     if (jkind) {
         CONFIG_IS_IN_ENUM_STRING(jkind, "pool kind", "fifo", "fifo_wait",
-                                 "prio_wait", "efirst_wait", "external");
+                                 "prio_wait", "earliest_first", "external");
         if (strcmp(json_object_get_string(jkind), "external") == 0) {
             margo_error(mid,
                         "Pool is marked as external and "
@@ -123,7 +123,7 @@ bool __margo_abt_pool_init_from_json(const json_object_t* jpool,
         if (ret != ABT_SUCCESS) {
             margo_error(mid, "ABT_pool_create failed with error code %d", ret);
         }
-    } else if (strcmp(pool->kind, "efirst_wait") == 0) {
+    } else if (strcmp(pool->kind, "earliest_first") == 0) {
         if (!pool->access) pool->access = strdup("mpmc");
         ABT_pool_def efirst_pool_def;
         margo_create_efirst_pool_def(&efirst_pool_def);

--- a/src/margo-abt-config.c
+++ b/src/margo-abt-config.c
@@ -37,7 +37,7 @@ bool __margo_abt_pool_validate_json(const json_object_t* jpool,
     json_object_t* jkind = json_object_object_get(jpool, "kind");
     if (jkind) {
         CONFIG_IS_IN_ENUM_STRING(jkind, "pool kind", "fifo", "fifo_wait",
-                                 "prio_wait", "external");
+                                 "prio_wait", "efirst_wait", "external");
         if (strcmp(json_object_get_string(jkind), "external") == 0) {
             margo_error(mid,
                         "Pool is marked as external and "
@@ -119,6 +119,15 @@ bool __margo_abt_pool_init_from_json(const json_object_t* jpool,
         ABT_pool_def prio_pool_def;
         margo_create_prio_pool_def(&prio_pool_def);
         ret = ABT_pool_create(&prio_pool_def, ABT_POOL_CONFIG_NULL,
+                              &pool->pool);
+        if (ret != ABT_SUCCESS) {
+            margo_error(mid, "ABT_pool_create failed with error code %d", ret);
+        }
+    } else if (strcmp(pool->kind, "efirst_wait") == 0) {
+        if (!pool->access) pool->access = strdup("mpmc");
+        ABT_pool_def efirst_pool_def;
+        margo_create_efirst_pool_def(&efirst_pool_def);
+        ret = ABT_pool_create(&efirst_pool_def, ABT_POOL_CONFIG_NULL,
                               &pool->pool);
         if (ret != ABT_SUCCESS) {
             margo_error(mid, "ABT_pool_create failed with error code %d", ret);

--- a/src/margo-abt-config.h
+++ b/src/margo-abt-config.h
@@ -16,6 +16,7 @@
 #include "margo.h"
 #include "margo-globals.h"
 #include "margo-prio-pool.h"
+#include "margo-efirst-pool.h"
 #include "margo-logging.h"
 #include "margo-macros.h"
 #include "margo-abt-macros.h"
@@ -51,10 +52,10 @@ typedef struct margo_abt margo_abt_t;
  * margo is responsible for explicitly free'ing the pool or not.
  */
 typedef struct margo_abt_pool {
-    char*          name;
-    ABT_pool       pool;
-    char*          kind;
-    optional_char* access;          /* Unknown for custom user pools */
+    char*             name;
+    ABT_pool          pool;
+    char*             kind;
+    optional_char*    access;       /* Unknown for custom user pools */
     _Atomic(uint32_t) num_rpc_ids;  /* Number of RPC ids that use this pool */
     _Atomic(uint32_t) num_xstreams; /* Number of xstreams that use this pool */
     bool margo_free_flag; /* flag if Margo is responsible for freeing */

--- a/src/margo-efirst-pool.c
+++ b/src/margo-efirst-pool.c
@@ -37,7 +37,7 @@ typedef struct queue_t {
     size_t   size;
 } queue_t;
 
-static queue_t* create_queue(size_t initial_capacity)
+static inline queue_t* create_queue(size_t initial_capacity)
 {
     queue_t* queue = (queue_t*)malloc(sizeof(queue_t));
     queue->entries = (entry_t*)malloc((initial_capacity + 1) * sizeof(entry_t));
@@ -46,21 +46,21 @@ static queue_t* create_queue(size_t initial_capacity)
     return queue;
 }
 
-static void destroy_queue(queue_t* queue)
+static inline void destroy_queue(queue_t* queue)
 {
     if (queue == NULL) return;
     free(queue->entries);
     free(queue);
 }
-
+/*
 static void swap_entries(entry_t* a, entry_t* b)
 {
     entry_t temp = *a;
     *a           = *b;
     *b           = temp;
 }
-
-void queue_push(queue_t* queue, unit_t* p_unit)
+*/
+static inline void queue_push(queue_t* queue, unit_t* p_unit)
 {
     if (queue->size >= queue->capacity) {
         size_t   new_capacity = queue->capacity * 2; // Double the capacity
@@ -112,43 +112,6 @@ static inline unit_t* queue_pop(queue_t* queue)
     min_entry->flag ^= IS_IN_POOL;
 
     return min_entry;
-}
-
-void queue_remove(queue_t* queue, unit_t* p_unit)
-{
-    for (size_t i = 1; i <= queue->size; ++i) {
-        if (queue->entries[i] == p_unit) {
-            queue->entries[i] = queue->entries[queue->size--];
-            size_t index      = i;
-
-            while (index * 2 <= queue->size) {
-                size_t child = index * 2;
-                if (child != queue->size
-                    && queue->entries[child + 1]->priority
-                           < queue->entries[child]->priority)
-                    child++;
-
-                if (queue->entries[child]->priority
-                    < queue->entries[index]->priority) {
-                    swap_entries(&queue->entries[index],
-                                 &queue->entries[child]);
-                    index = child;
-                } else {
-                    break;
-                }
-            }
-
-            while (index > 1
-                   && queue->entries[index]->priority
-                          < queue->entries[index / 2]->priority) {
-                swap_entries(&queue->entries[index],
-                             &queue->entries[index / 2]);
-                index /= 2;
-            }
-
-            break;
-        }
-    }
 }
 
 typedef struct pool_t {

--- a/src/margo-efirst-pool.c
+++ b/src/margo-efirst-pool.c
@@ -1,0 +1,305 @@
+/*
+ * (C) 2021 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <abt.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "margo-efirst-pool.h"
+
+/* ABT_POOL_EFIRST_WAIT */
+
+/* This is a custom Argobots pool, compatible with ABT_POOL_FIFO_WAIT, that
+ * prioritize the earliest posted threads/tasks over latter ones, using a
+ * min-heap structure as an implementation of a priority queue.
+ */
+
+#define IS_IN_POOL 0x1
+#define IS_THREAD  0x2
+
+typedef struct unit_t {
+    union {
+        ABT_thread thread;
+        ABT_task   task;
+    };
+    uint64_t priority;
+    char     flag; // uses IS_IN_POOL and IS_THREAD
+} unit_t;
+
+typedef unit_t* entry_t;
+
+typedef struct queue_t {
+    entry_t* entries;
+    size_t   capacity;
+    size_t   size;
+} queue_t;
+
+static queue_t* create_queue(size_t initial_capacity)
+{
+    queue_t* queue = (queue_t*)malloc(sizeof(queue_t));
+    queue->entries = (entry_t*)malloc((initial_capacity + 1) * sizeof(entry_t));
+    queue->capacity = initial_capacity;
+    queue->size     = 0;
+    return queue;
+}
+
+static void destroy_queue(queue_t* queue)
+{
+    if (queue == NULL) return;
+    free(queue->entries);
+    free(queue);
+}
+
+static void swap_entries(entry_t* a, entry_t* b)
+{
+    entry_t temp = *a;
+    *a           = *b;
+    *b           = temp;
+}
+
+void queue_push(queue_t* queue, unit_t* p_unit)
+{
+    if (queue->size >= queue->capacity) {
+        size_t   new_capacity = queue->capacity * 2; // Double the capacity
+        entry_t* new_entries  = (entry_t*)realloc(
+            queue->entries, (new_capacity + 1) * sizeof(entry_t));
+        queue->entries  = new_entries;
+        queue->capacity = new_capacity;
+    }
+
+    entry_t new_entry = p_unit;
+    size_t  index     = ++queue->size;
+
+    while (index > 1
+           && new_entry->priority < queue->entries[index / 2]->priority) {
+        queue->entries[index] = queue->entries[index / 2];
+        index /= 2;
+    }
+
+    queue->entries[index] = new_entry;
+    p_unit->flag |= IS_IN_POOL;
+}
+
+static inline unit_t* queue_pop(queue_t* queue)
+{
+    if (queue->size == 0) { return NULL; }
+
+    entry_t min_entry  = queue->entries[1];
+    entry_t last_entry = queue->entries[queue->size--];
+
+    size_t index = 1;
+    size_t child;
+
+    while (index * 2 <= queue->size) {
+        child = index * 2;
+        if (child != queue->size
+            && queue->entries[child + 1]->priority
+                   < queue->entries[child]->priority)
+            child++;
+
+        if (last_entry->priority > queue->entries[child]->priority)
+            queue->entries[index] = queue->entries[child];
+        else
+            break;
+
+        index = child;
+    }
+
+    queue->entries[index] = last_entry;
+    min_entry->flag ^= IS_IN_POOL;
+
+    return min_entry;
+}
+
+void queue_remove(queue_t* queue, unit_t* p_unit)
+{
+    for (size_t i = 1; i <= queue->size; ++i) {
+        if (queue->entries[i] == p_unit) {
+            queue->entries[i] = queue->entries[queue->size--];
+            size_t index      = i;
+
+            while (index * 2 <= queue->size) {
+                size_t child = index * 2;
+                if (child != queue->size
+                    && queue->entries[child + 1]->priority
+                           < queue->entries[child]->priority)
+                    child++;
+
+                if (queue->entries[child]->priority
+                    < queue->entries[index]->priority) {
+                    swap_entries(&queue->entries[index],
+                                 &queue->entries[child]);
+                    index = child;
+                } else {
+                    break;
+                }
+            }
+
+            while (index > 1
+                   && queue->entries[index]->priority
+                          < queue->entries[index / 2]->priority) {
+                swap_entries(&queue->entries[index],
+                             &queue->entries[index / 2]);
+                index /= 2;
+            }
+
+            break;
+        }
+    }
+}
+
+typedef struct pool_t {
+    queue_t*        queue;
+    uint64_t        num; // number of new units created so far
+    pthread_mutex_t mutex;
+    pthread_cond_t  cond;
+} pool_t;
+
+static ABT_unit_type pool_unit_get_type(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    if (p_unit->flag & IS_THREAD) {
+        return ABT_UNIT_TYPE_THREAD;
+    } else {
+        return ABT_UNIT_TYPE_TASK;
+    }
+}
+
+static ABT_thread pool_unit_get_thread(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    return p_unit->thread;
+}
+
+static ABT_task pool_unit_get_task(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    return p_unit->task;
+}
+
+static ABT_bool pool_unit_is_in_pool(ABT_unit unit)
+{
+    unit_t* p_unit = (unit_t*)unit;
+    return p_unit->flag & IS_IN_POOL;
+}
+
+static ABT_unit pool_unit_create_from_thread(ABT_thread thread)
+{
+    unit_t* p_unit = (unit_t*)calloc(1, sizeof(unit_t));
+    p_unit->thread = thread;
+    p_unit->flag   = IS_THREAD;
+    return (ABT_unit)p_unit;
+}
+
+static ABT_unit pool_unit_create_from_task(ABT_task task)
+{
+    unit_t* p_unit = (unit_t*)calloc(1, sizeof(unit_t));
+    p_unit->task   = task;
+    return (ABT_unit)p_unit;
+}
+
+static void pool_unit_free(ABT_unit* p_unit)
+{
+    free(*p_unit);
+    *p_unit = ABT_UNIT_NULL;
+}
+
+static int pool_init(ABT_pool pool, ABT_pool_config config)
+{
+    (void)config;
+    pool_t* p_pool = (pool_t*)calloc(1, sizeof(pool_t));
+    p_pool->queue  = create_queue(32);
+    pthread_mutex_init(&p_pool->mutex, NULL);
+    pthread_cond_init(&p_pool->cond, NULL);
+    ABT_pool_set_data(pool, (void*)p_pool);
+    return ABT_SUCCESS;
+}
+
+static size_t pool_get_size(ABT_pool pool)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    return p_pool->queue->size;
+}
+
+static void pool_push(ABT_pool pool, ABT_unit unit)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    unit_t* p_unit = (unit_t*)unit;
+    pthread_mutex_lock(&p_pool->mutex);
+    if (p_unit->priority == 0) {
+        p_pool->num += 1;
+        p_unit->priority = p_pool->num;
+    }
+    queue_push(p_pool->queue, p_unit);
+    pthread_cond_signal(&p_pool->cond);
+    pthread_mutex_unlock(&p_pool->mutex);
+}
+
+static ABT_unit pool_pop(ABT_pool pool)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    pthread_mutex_lock(&p_pool->mutex);
+    unit_t* p_unit = queue_pop(p_pool->queue);
+    pthread_mutex_unlock(&p_pool->mutex);
+    return p_unit ? (ABT_unit)p_unit : ABT_UNIT_NULL;
+}
+
+static inline void convert_double_sec_to_timespec(struct timespec* ts_out,
+                                                  double           seconds)
+{
+    ts_out->tv_sec  = (time_t)seconds;
+    ts_out->tv_nsec = (long)((seconds - ts_out->tv_sec) * 1000000000.0);
+}
+
+static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    pthread_mutex_lock(&p_pool->mutex);
+    if (p_pool->queue->size == 0) {
+        struct timespec ts;
+        convert_double_sec_to_timespec(&ts, abstime_secs);
+        pthread_cond_timedwait(&p_pool->cond, &p_pool->mutex, &ts);
+    }
+    unit_t* p_unit = queue_pop(p_pool->queue);
+    pthread_mutex_unlock(&p_pool->mutex);
+    return p_unit ? (ABT_unit)p_unit : ABT_UNIT_NULL;
+}
+
+static int pool_free(ABT_pool pool)
+{
+    pool_t* p_pool;
+    ABT_pool_get_data(pool, (void**)&p_pool);
+    destroy_queue(p_pool->queue);
+    pthread_mutex_destroy(&p_pool->mutex);
+    pthread_cond_destroy(&p_pool->cond);
+    free(p_pool);
+
+    return ABT_SUCCESS;
+}
+
+void margo_create_efirst_pool_def(ABT_pool_def* p_def)
+{
+    p_def->access               = ABT_POOL_ACCESS_MPMC;
+    p_def->u_get_type           = pool_unit_get_type;
+    p_def->u_get_thread         = pool_unit_get_thread;
+    p_def->u_get_task           = pool_unit_get_task;
+    p_def->u_is_in_pool         = pool_unit_is_in_pool;
+    p_def->u_create_from_thread = pool_unit_create_from_thread;
+    p_def->u_create_from_task   = pool_unit_create_from_task;
+    p_def->u_free               = pool_unit_free;
+    p_def->p_init               = pool_init;
+    p_def->p_get_size           = pool_get_size;
+    p_def->p_push               = pool_push;
+    p_def->p_pop                = pool_pop;
+    p_def->p_pop_timedwait      = pool_pop_timedwait;
+    p_def->p_remove             = NULL; /* Optional */
+    p_def->p_free               = pool_free;
+    p_def->p_print_all          = NULL; /* Optional */
+}

--- a/src/margo-efirst-pool.c
+++ b/src/margo-efirst-pool.c
@@ -290,7 +290,7 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
     pool_t* p_pool;
     ABT_pool_get_data(pool, (void**)&p_pool);
     pthread_mutex_lock(&p_pool->mutex);
-    if (p_pool->queue->prio.size == 0) {
+    if (p_pool->queue->prio.size == 0 && p_pool->queue->fifo.size) {
         struct timespec ts;
         convert_double_sec_to_timespec(&ts, abstime_secs);
         pthread_cond_timedwait(&p_pool->cond, &p_pool->mutex, &ts);

--- a/src/margo-efirst-pool.c
+++ b/src/margo-efirst-pool.c
@@ -52,14 +52,7 @@ static inline void destroy_queue(queue_t* queue)
     free(queue->entries);
     free(queue);
 }
-/*
-static void swap_entries(entry_t* a, entry_t* b)
-{
-    entry_t temp = *a;
-    *a           = *b;
-    *b           = temp;
-}
-*/
+
 static inline void queue_push(queue_t* queue, unit_t* p_unit)
 {
     if (queue->size >= queue->capacity) {

--- a/src/margo-efirst-pool.c
+++ b/src/margo-efirst-pool.c
@@ -170,10 +170,12 @@ static inline unit_t* queue_pop_old(queue_t* queue)
 static inline unit_t* queue_pop(queue_t* queue)
 {
     queue->pops += 1;
-    if (queue->pops % 2 == 0 && queue->old.size > 0)
-        return queue_pop_old(queue);
+    if (queue->pops % 2 == 0)
+        return queue->old.size > 0 ? queue_pop_old(queue)
+                                   : queue_pop_new(queue);
     else
-        return queue_pop_new(queue);
+        return queue->new.size > 0 ? queue_pop_new(queue)
+                                   : queue_pop_old(queue);
 }
 
 typedef struct pool_t {

--- a/src/margo-efirst-pool.h
+++ b/src/margo-efirst-pool.h
@@ -1,0 +1,22 @@
+/*
+ * (C) 2021 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef __MARGO_EFIRST_POOL
+#define __MARGO_EFIRST_POOL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <abt.h>
+
+void margo_create_efirst_pool_def(ABT_pool_def* p_def);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MARGO_EFIRST_POOL */

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -48,6 +48,7 @@ static int count_occurrence(const char* haystack, const char *needle)
 }
 
 static void thread_func(void* args) {
+    ABT_thread_yield();
     (void)args;
 }
 
@@ -107,12 +108,12 @@ static MunitResult rpc_pool_kind(const MunitParameter params[], void* data)
     hg_return_t hret = margo_find_pool_by_name(ctx->mid, "my_pool", &info);
     munit_assert_int_goto(hret, ==, HG_SUCCESS, error);
 
-    // try to post 4 ULTs to the pool
-    ABT_thread ults[4];
-    for(unsigned i=0; i < 4; ++i) {
+    // try to post 64 ULTs to the pool
+    ABT_thread ults[64];
+    for(unsigned i=0; i < 64; ++i) {
         ABT_thread_create(info.pool, thread_func, NULL, ABT_THREAD_ATTR_NULL, ults+i);
     }
-    for(unsigned i=0; i < 4; ++i) {
+    for(unsigned i=0; i < 64; ++i) {
         ABT_thread_join(ults[i]);
         ABT_thread_free(ults+i);
     }

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -48,8 +48,20 @@ static int count_occurrence(const char* haystack, const char *needle)
 }
 
 static void thread_func(void* args) {
-    ABT_thread_yield();
     (void)args;
+    // This ULT is meant to test mostly the efirst_wait queue.
+    // Some instances will yield 64 times, leading them to become
+    // "old" ULTs. Other will yield only once.
+    ABT_thread self;
+    ABT_thread_self(&self);
+    ABT_unit_id rank;
+    ABT_thread_get_id(self, &rank);
+    if(rank % 2 == 0) {
+        for(unsigned i = 0; i < 64; ++i)
+            ABT_thread_yield();
+    } else {
+        ABT_thread_yield();
+    }
 }
 
 /* test different ways of specifying different "kind" for

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -47,6 +47,8 @@ static int count_occurrence(const char* haystack, const char *needle)
     return(count);
 }
 
+static void thread_func(void*) {}
+
 /* test different ways of specifying different "kind" for
  * dedicated rpc handler pool
  */
@@ -58,7 +60,29 @@ static MunitResult rpc_pool_kind(const MunitParameter params[], void* data)
     char *runtime_config;
     int count;
 
-    mii.json_config = munit_parameters_get(params, "json");
+    const char* config_fmt = "{"
+        "\"rpc_thread_count\":0,"
+        "\"argobots\": {"
+            "\"pools\": ["
+                "{ \"name\":\"my_pool\", \"kind\":\"%s\" }"
+            "],"
+            "\"xstreams\": ["
+                "{ \"name\":\"my_xstream\", "
+                  "\"scheduler\": {"
+                    "\"type\":\"basic_wait\","
+                    "\"pools\":[\"my_pool\"]"
+                  "}"
+                "}"
+            "]"
+        "}"
+    "}";
+
+    const char* pool_kind = munit_parameters_get(params, "pool");
+
+    char config[4096] = {0};
+    sprintf(config, config_fmt, pool_kind);
+
+    mii.json_config = config;
 
     ctx->mid = margo_init_ext(protocol, MARGO_SERVER_MODE, &mii);
     munit_assert_not_null_goto(ctx->mid, error);
@@ -72,14 +96,24 @@ static MunitResult rpc_pool_kind(const MunitParameter params[], void* data)
     munit_assert_int_goto(count, ==, 1, error);
 
     /* just one pool with the prio_wait kind */
-    if(count_occurrence(mii.json_config, "prio_wait")) {
-        count = count_occurrence(runtime_config, "prio_wait");
-    } else if(count_occurrence(mii.json_config, "efirst_wait")) {
-        count = count_occurrence(runtime_config, "efirst_wait");
-    }
+    count = count_occurrence(runtime_config, pool_kind);
     munit_assert_int_goto(count, ==, 1, error);
 
     free(runtime_config);
+
+    struct margo_pool_info info = {0};
+    hg_return_t hret = margo_find_pool_by_name(ctx->mid, "my_pool", &info);
+    munit_assert_int_goto(hret, ==, HG_SUCCESS, error);
+
+    // try to post 4 ULTs to the pool
+    ABT_thread ults[4];
+    for(unsigned i=0; i < 4; ++i) {
+        ABT_thread_create(info.pool, thread_func, NULL, ABT_THREAD_ATTR_NULL, ults+i);
+    }
+    for(unsigned i=0; i < 4; ++i) {
+        ABT_thread_join(ults[i]);
+        ABT_thread_free(ults+i);
+    }
 
     margo_finalize(ctx->mid);
 
@@ -89,14 +123,19 @@ error:
     return MUNIT_FAIL;
 }
 
+static char* pool_params[] = {
+    "prio_wait",
+    "efirst_wait",
+    NULL
+};
+
 static char * json_params[] = {
-    "{ \"rpc_thread_count\":0, \"argobots\":{ \"pools\":[ { \"name\":\"my_pool\", \"kind\":\"prio_wait\" } ] } }",
     "{ \"rpc_thread_count\":0, \"argobots\":{ \"pools\":[ { \"name\":\"my_pool\", \"kind\":\"efirst_wait\" } ] } }",
     NULL
 };
 
 static MunitParameterEnum rpc_pool_kind_params[] = {
-    { "json", json_params},
+    { "pool", pool_params},
     {NULL, NULL}
 };
 

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -72,7 +72,11 @@ static MunitResult rpc_pool_kind(const MunitParameter params[], void* data)
     munit_assert_int_goto(count, ==, 1, error);
 
     /* just one pool with the prio_wait kind */
-    count = count_occurrence(runtime_config, "prio_wait");
+    if(count_occurrence(mii.json_config, "prio_wait")) {
+        count = count_occurrence(runtime_config, "prio_wait");
+    } else if(count_occurrence(mii.json_config, "efirst_wait")) {
+        count = count_occurrence(runtime_config, "efirst_wait");
+    }
     munit_assert_int_goto(count, ==, 1, error);
 
     free(runtime_config);
@@ -86,7 +90,9 @@ error:
 }
 
 static char * json_params[] = {
-    "{ \"rpc_thread_count\":0, \"argobots\":{ \"pools\":[ { \"name\":\"my_pool\", \"kind\":\"prio_wait\" } ] } }", NULL
+    "{ \"rpc_thread_count\":0, \"argobots\":{ \"pools\":[ { \"name\":\"my_pool\", \"kind\":\"prio_wait\" } ] } }",
+    "{ \"rpc_thread_count\":0, \"argobots\":{ \"pools\":[ { \"name\":\"my_pool\", \"kind\":\"efirst_wait\" } ] } }",
+    NULL
 };
 
 static MunitParameterEnum rpc_pool_kind_params[] = {

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -47,7 +47,9 @@ static int count_occurrence(const char* haystack, const char *needle)
     return(count);
 }
 
-static void thread_func(void*) {}
+static void thread_func(void* args) {
+    (void)args;
+}
 
 /* test different ways of specifying different "kind" for
  * dedicated rpc handler pool

--- a/tests/unit-tests/margo-abt-pool.c
+++ b/tests/unit-tests/margo-abt-pool.c
@@ -49,7 +49,7 @@ static int count_occurrence(const char* haystack, const char *needle)
 
 static void thread_func(void* args) {
     (void)args;
-    // This ULT is meant to test mostly the efirst_wait queue.
+    // This ULT is meant to test mostly the earliest_first queue.
     // Some instances will yield 64 times, leading them to become
     // "old" ULTs. Other will yield only once.
     ABT_thread self;
@@ -140,12 +140,7 @@ error:
 
 static char* pool_params[] = {
     "prio_wait",
-    "efirst_wait",
-    NULL
-};
-
-static char * json_params[] = {
-    "{ \"rpc_thread_count\":0, \"argobots\":{ \"pools\":[ { \"name\":\"my_pool\", \"kind\":\"efirst_wait\" } ] } }",
+    "earliest_first",
     NULL
 };
 

--- a/tests/unit-tests/margo-forward.c
+++ b/tests/unit-tests/margo-forward.c
@@ -665,7 +665,7 @@ error:
 }
 
 static char* protocol_params[] = {"na+sm", NULL};
-static char* progress_pool_params[] = {"fifo_wait", "prio_wait", "efirst_wait", NULL};
+static char* progress_pool_params[] = {"fifo_wait", "prio_wait", "earliest_first", NULL};
 
 static MunitParameterEnum test_params[]
     = {{"protocol", protocol_params},

--- a/tests/unit-tests/margo-forward.c
+++ b/tests/unit-tests/margo-forward.c
@@ -75,12 +75,33 @@ static void* test_context_setup(const MunitParameter params[], void* user_data)
     struct test_context* ctx = calloc(1, sizeof(*ctx));
 
     const char* protocol         = munit_parameters_get(params, "protocol");
+    const char* progress_pool    = munit_parameters_get(params, "progress_pool");
     hg_size_t   remote_addr_size = 256;
-    ctx->remote_pid = HS_start(protocol, NULL, svr_init_fn, NULL, NULL,
+
+    char config[4096];
+    const char* config_fmt = "{"
+          "\"rpc_pool\":\"p\","
+          "\"progress_pool\":\"p\","
+          "\"argobots\": {"
+              "\"pools\": ["
+                  "{ \"name\":\"p\", \"kind\":\"%s\" }"
+              "],"
+              "\"xstreams\": ["
+                  "{ \"name\":\"__progress__\","
+                    "\"scheduler\": {\"type\":\"basic_wait\", \"pools\":[\"p\"]}"
+                  "}"
+              "],"
+          "}"
+      "}";
+    sprintf(config, config_fmt, progress_pool);
+
+    struct margo_init_info init_info = {0};
+    init_info.json_config = config;
+    ctx->remote_pid = HS_start(protocol, &init_info, svr_init_fn, NULL, NULL,
                                &(ctx->remote_addr[0]), &remote_addr_size);
     munit_assert_int(ctx->remote_pid, >, 0);
 
-    ctx->mid = margo_init(protocol, MARGO_SERVER_MODE, 0, 0);
+    ctx->mid = margo_init_ext(protocol, MARGO_SERVER_MODE, &init_info);
     if(!ctx->mid) {
         HS_stop(ctx->remote_pid, 0);
     }
@@ -644,9 +665,12 @@ error:
 }
 
 static char* protocol_params[] = {"na+sm", NULL};
+static char* progress_pool_params[] = {"fifo_wait", "prio_wait", "efirst_wait", NULL};
 
 static MunitParameterEnum test_params[]
-    = {{"protocol", protocol_params}, {NULL, NULL}};
+    = {{"protocol", protocol_params},
+       {"progress_pool", progress_pool_params},
+       {NULL, NULL}};
 
 static MunitTest test_suite_tests[] = {
     {(char*)"/forward", test_forward, test_context_setup,


### PR DESCRIPTION
The `erliest_first` pool is a pool that prioritizes the ULTs based on the order in which they have been created. It does so using a min-heap-based priority queue + a FIFO queue.

The pool maintains a counter of ULTs created in it since its creation. When a new ULT is created and pushed into the pool, its priority is set to the pool's current counter and the counter is increased. The ULT is placed in the min-heap priority queue. Each ULT also keeps track of how many time it has been popped from the pool. When the ULT is pushed back in the pool, if this number is lower than 32, it goes back in the priority queue. If it's greater or equal to 32, it goes into the FIFO queue. The FIFO queue represents "old" (potentially long-running) ULTs, for which it no longer makes sense to assign a priority. For instance the progress ULT in margo would go in that FIFO queue, or the ticker ULT in mochi-raft.

When popping a ULT out of the pool, the pool will alternate between popping from the priority queue and from the FIFO queue.