### PR TITLE
fixing margo-eventual unit test

### DIFF
--- a/tests/unit-tests/margo-eventual.c
+++ b/tests/unit-tests/margo-eventual.c
@@ -63,7 +63,7 @@ void waiter_fn(void* _arg)
 }
 
 struct ev_queue_element {
-    margo_eventual_t*        ev;
+    margo_eventual_t         ev;
     struct ev_queue_element* next;
 };
 
@@ -73,24 +73,24 @@ ABT_cond                 ev_queue_cond;
 
 void waiter_sub_fn(void)
 {
-    margo_eventual_t         ev;
     struct ev_queue_element* q_e;
 
     q_e = malloc(sizeof(*q_e));
     munit_assert_not_null(q_e);
 
-    MARGO_EVENTUAL_CREATE(&ev);
+    MARGO_EVENTUAL_CREATE(&q_e->ev);
 
     ABT_mutex_lock(ev_queue_mutex);
-    q_e->ev       = &ev;
     q_e->next     = ev_queue_head;
     ev_queue_head = q_e;
     ABT_cond_signal(ev_queue_cond);
     ABT_mutex_unlock(ev_queue_mutex);
 
-    MARGO_EVENTUAL_WAIT(ev);
+    MARGO_EVENTUAL_WAIT(q_e->ev);
 
-    MARGO_EVENTUAL_FREE(&ev);
+    MARGO_EVENTUAL_FREE(&q_e->ev);
+
+    free(q_e);
 
     return;
 }
@@ -141,8 +141,7 @@ static MunitResult margo_eventual_iteration(const MunitParameter params[],
         ev_queue_head = q_e->next;
         ABT_mutex_unlock(ev_queue_mutex);
 
-        MARGO_EVENTUAL_SET(*q_e->ev);
-        free(q_e);
+        MARGO_EVENTUAL_SET(q_e->ev);
     }
 
     for (i = 0; i < N_ULTS; i++) { ABT_thread_join(tid_array[i]); }

--- a/tests/unit-tests/margo-eventual.c
+++ b/tests/unit-tests/margo-eventual.c
@@ -55,8 +55,6 @@ void waiter_fn(void* _arg)
 {
     margo_eventual_t* ev = (margo_eventual_t*)_arg;
 
-    MARGO_EVENTUAL_CREATE(ev);
-
     MARGO_EVENTUAL_WAIT(*ev);
 
     MARGO_EVENTUAL_FREE(ev);
@@ -173,6 +171,10 @@ static MunitResult margo_eventual(const MunitParameter params[], void* data)
     margo_get_handler_pool(ctx->mid, &rpc_pool);
 
     for (i = 0; i < N_ULTS; i++) {
+        MARGO_EVENTUAL_CREATE(&iter_array[i].ev);
+    }
+
+    for (i = 0; i < N_ULTS; i++) {
         ABT_thread_create(rpc_pool, waiter_fn, &iter_array[i].ev,
                           ABT_THREAD_ATTR_NULL, &iter_array[i].waiter_tid);
     }
@@ -187,7 +189,6 @@ static MunitResult margo_eventual(const MunitParameter params[], void* data)
     for (i = 0; i < N_ULTS; i++) {
         ABT_thread_join(iter_array[i].waiter_tid);
         ABT_thread_join(iter_array[i].setter_tid);
-        MARGO_EVENTUAL_FREE(&iter_array[i].ev);
     }
 
     free(iter_array);


### PR DESCRIPTION
Looking into fixing https://github.com/mochi-hpc/mochi-margo/issues/266.

There was 2 problems with the margo_eventual test:
- The eventual is created, waited, and freed by the "waiter_fn", and set of by "setter_fn". This assumes that the setter function does not start before the waiter, otherwise it gets a garbage data instead of an eventual because the eventual hasn't been created (normally this shouldn't happen because of `margo_thread_sleep` though, but better write a correct program to begin with). In all of margo, the eventual is always created before anything is going to attempt to access it.
- The eventual was freed twice. Once in the waiter_fn, and another time at the end of the test function. I don't think we ever ran into a problem with that because with a recent enough version of Argobots, MARGO_EVENTUAL_FREE translated into an ABT_eventual_reset, so a double-free becomes a double-reset, which is fine.

That said the https://github.com/mochi-hpc/mochi-margo/issues/266 finds ASAN problems in the `margo_eventual_iteration` test function, and not in the `margo_eventual` test function. What I think happens is this:

`margo_eventual_t` is not an opaque pointer type, it's the actual eventual memory. So in `waiter_sub_fn`, `ev` is a stack variable. We assign its address to `q_e->ev` and this address is picked up in the while loop of the `margo_eventual_iteration` function, where we call `MARGO_EVENTUAL_SET(*q_e->ev)`. This translates via macros into something like this: `ABT_EVENTUAL_MEMORY_GET_HANDLE(&(*q_e->ev))` which I don't think is correct. We are creating a temporary eventual memory on the stack (let's call it `t = *q_e->ev`) then taking its address (`&t`), technically using it after `t` has virtually disappeared.

In comparison, in the margo code, `MARGO_EVENTUAL_SET` is only used once, in `margo_cb`, where it takes this form:

```
MARGO_EVENTUAL_SET(req->u.eventual.ev);
```

This is correct, we are not creating a temporary and taking its address.

That said, note that in `setter_fn` we are also doing `MARGO_EVENTUAL_SET(*ev);`, so ASAN should yell at us as well. Not sure why it doesn't.

Anyway, the second commit in this PR fixes the problem by having `margo_eventual_t ev` be a member of a queue element (rather than the queue element holding a pointer to it). The queue element is also freed in the waiter_sub_fn function rather than in the while loop of `margo_eventual_iteration`.

@carns can you check that ASAN is now happy on your side?