### PR TITLE
Dev provider names

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -785,6 +785,67 @@ hg_return_t margo_register_data(margo_instance_id mid,
 void* margo_registered_data(margo_instance_id mid, hg_id_t id);
 
 /**
+ * @brief Give a name for the provider with the specified provider ID.
+ * This will effectively register an internal RPC that can be invoked
+ * by using margo_provider_get_identity.
+ *
+ * @param mid Margo instance.
+ * @param provider_id Provider ID.
+ * @param identity Identity (name) of the provider.
+ *
+ * @return HG_SUCCESS or corresponding error code.
+ */
+hg_return_t margo_provider_register_identity(margo_instance_id mid,
+                                             uint16_t provider_id,
+                                             const char* identity);
+
+/**
+ * @brief Deregisters the identity associated with the provider ID.
+ *
+ * @param mid Margo instance.
+ * @param provider_id Provider ID.
+ *
+ * @return HG_SUCCESS or corresponding error code.
+ */
+hg_return_t margo_provider_deregister_identity(margo_instance_id mid,
+                                               uint16_t provider_id);
+
+/**
+ * @brief Get the identity registered with a provider ID.
+ * NULL will be returned if no such ID exists.
+ *
+ * @param mid Margo instance.
+ * @param provider_id Provider ID.
+ *
+ * @return Identity.
+ */
+const char* margo_provider_registered_identity(margo_instance_id mid,
+                                               uint16_t provider_id);
+
+/**
+ * @brief Get the identity of a provider.
+ *
+ * Note: if the buffer if too small, the function will return
+ * HG_NOMEM and the bufsize variable will be set to the required size.
+ *
+ * Note: if there is no provider registered with this ID or if it has
+ * not specified an identity, this function will return HG_NOENTRY.
+ *
+ * @param mid Margo instance.
+ * @param address Address.
+ * @param provider_id Provider ID.
+ * @param buffer Buffer in which to write the identity.
+ * @param bufsize Buffer capacity (in) / size of the identity (out).
+ *
+ * @return HG_SUCCESS or corresponding error code.
+ */
+hg_return_t margo_provider_get_identity(margo_instance_id mid,
+                                        hg_addr_t address,
+                                        uint16_t provider_id,
+                                        char* buffer,
+                                        size_t* bufsize);
+
+/**
  * @brief Get the name with which an RPC id was registered
  * (NULL if the RPC id is invalid or wasn't registered with a name).
  *

--- a/include/margo.h
+++ b/include/margo.h
@@ -65,8 +65,7 @@ typedef void (*margo_finalize_callback_t)(void*);
 /**
  * @brief Type of margo_request.
  */
-typedef enum
-{
+typedef enum {
     MARGO_RESPONSE_REQUEST = 2,
     MARGO_FORWARD_REQUEST  = 4,
     MARGO_BULK_REQUEST     = 6,
@@ -796,8 +795,8 @@ void* margo_registered_data(margo_instance_id mid, hg_id_t id);
  * @return HG_SUCCESS or corresponding error code.
  */
 hg_return_t margo_provider_register_identity(margo_instance_id mid,
-                                             uint16_t provider_id,
-                                             const char* identity);
+                                             uint16_t          provider_id,
+                                             const char*       identity);
 
 /**
  * @brief Deregisters the identity associated with the provider ID.
@@ -808,7 +807,7 @@ hg_return_t margo_provider_register_identity(margo_instance_id mid,
  * @return HG_SUCCESS or corresponding error code.
  */
 hg_return_t margo_provider_deregister_identity(margo_instance_id mid,
-                                               uint16_t provider_id);
+                                               uint16_t          provider_id);
 
 /**
  * @brief Get the identity registered with a provider ID.
@@ -820,7 +819,7 @@ hg_return_t margo_provider_deregister_identity(margo_instance_id mid,
  * @return Identity.
  */
 const char* margo_provider_registered_identity(margo_instance_id mid,
-                                               uint16_t provider_id);
+                                               uint16_t          provider_id);
 
 /**
  * @brief Get the identity of a provider.
@@ -840,10 +839,10 @@ const char* margo_provider_registered_identity(margo_instance_id mid,
  * @return HG_SUCCESS or corresponding error code.
  */
 hg_return_t margo_provider_get_identity(margo_instance_id mid,
-                                        hg_addr_t address,
-                                        uint16_t provider_id,
-                                        char* buffer,
-                                        size_t* bufsize);
+                                        hg_addr_t         address,
+                                        uint16_t          provider_id,
+                                        char*             buffer,
+                                        size_t*           bufsize);
 
 /**
  * @brief Get the name with which an RPC id was registered

--- a/src/Makefile.subdir
+++ b/src/Makefile.subdir
@@ -25,6 +25,7 @@ src_libmargo_la_SOURCES += \
  src/margo-globals.c \
  src/margo-handle-cache.c \
  src/margo-init.c \
+ src/margo-identity.c \
  src/margo-logging.c \
  src/margo-timer.c \
  src/margo-util.c \

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -124,6 +124,7 @@ static void margo_cleanup(margo_instance_id mid)
     __MARGO_MONITOR(mid, FN_START, finalize, monitoring_args);
 
     margo_deregister(mid, mid->shutdown_rpc_id);
+    margo_deregister(mid, mid->identity_rpc_id);
 
     /* call finalize callbacks */
     MARGO_TRACE(mid, "Calling finalize callbacks");

--- a/src/margo-identity.c
+++ b/src/margo-identity.c
@@ -9,64 +9,65 @@
 #include <string.h>
 #include <stdlib.h>
 
-static void  get_identity(hg_handle_t handle)
+static void get_identity(hg_handle_t handle)
 {
-    const struct hg_info* info     = margo_get_info(handle);
-    margo_instance_id     mid      = margo_hg_handle_get_instance(handle);
-    hg_string_t           identity = (hg_string_t)margo_registered_data(mid, info->id);
+    const struct hg_info* info = margo_get_info(handle);
+    margo_instance_id     mid  = margo_hg_handle_get_instance(handle);
+    hg_string_t identity = (hg_string_t)margo_registered_data(mid, info->id);
     margo_respond(handle, &identity);
     margo_destroy(handle);
 }
 DEFINE_MARGO_RPC_HANDLER(get_identity)
 
 hg_return_t margo_provider_register_identity(margo_instance_id mid,
-                                             uint16_t provider_id,
-                                             const char* identity)
+                                             uint16_t          provider_id,
+                                             const char*       identity)
 {
-    if(!identity) return HG_INVALID_ARG;
-    hg_id_t id = MARGO_REGISTER_PROVIDER(
-        mid, "__identity__", void, hg_string_t, get_identity, provider_id, ABT_POOL_NULL);
-    if(!id) return HG_OTHER_ERROR;
+    if (!identity) return HG_INVALID_ARG;
+    hg_id_t id
+        = MARGO_REGISTER_PROVIDER(mid, "__identity__", void, hg_string_t,
+                                  get_identity, provider_id, ABT_POOL_NULL);
+    if (!id) return HG_OTHER_ERROR;
     char* data = strdup(identity);
     margo_register_data(mid, id, data, free);
     return HG_SUCCESS;
 }
 
 hg_return_t margo_provider_deregister_identity(margo_instance_id mid,
-                                               uint16_t provider_id)
+                                               uint16_t          provider_id)
 {
     hg_id_t     id;
     hg_bool_t   flag = HG_FALSE;
     hg_return_t hret;
-    hret = margo_provider_registered_name(
-        mid, "__identity__", provider_id, &id, &flag);
-    if(hret != HG_SUCCESS) return hret;
-    if(!flag) return HG_NOENTRY;
+    hret = margo_provider_registered_name(mid, "__identity__", provider_id, &id,
+                                          &flag);
+    if (hret != HG_SUCCESS) return hret;
+    if (!flag) return HG_NOENTRY;
     margo_deregister(mid, id);
     return HG_SUCCESS;
 }
 
 const char* margo_provider_registered_identity(margo_instance_id mid,
-                                               uint16_t provider_id)
+                                               uint16_t          provider_id)
 {
     hg_id_t     id;
     hg_bool_t   flag = HG_FALSE;
     hg_return_t hret;
-    hret = margo_provider_registered_name(
-        mid, "__identity__", provider_id, &id, &flag);
-    if(hret != HG_SUCCESS) return NULL;
-    if(!flag) return NULL;
+    hret = margo_provider_registered_name(mid, "__identity__", provider_id, &id,
+                                          &flag);
+    if (hret != HG_SUCCESS) return NULL;
+    if (!flag) return NULL;
     const char* identity = margo_registered_data(mid, id);
     return identity;
 }
 
 hg_return_t margo_provider_get_identity(margo_instance_id mid,
-                                        hg_addr_t address,
-                                        uint16_t provider_id,
-                                        char* buffer,
-                                        size_t* bufsize)
+                                        hg_addr_t         address,
+                                        uint16_t          provider_id,
+                                        char*             buffer,
+                                        size_t*           bufsize)
 {
-    if(!bufsize || !buffer) return HG_INVALID_ARG;
+    if (!bufsize || !buffer) return HG_INVALID_ARG;
 
     hg_string_t out  = NULL;
     hg_handle_t h    = HG_HANDLE_NULL;
@@ -75,23 +76,23 @@ hg_return_t margo_provider_get_identity(margo_instance_id mid,
     hg_bool_t   flag = HG_FALSE;
 
     hret = margo_create(mid, address, mid->identity_rpc_id, &h);
-    if(hret != HG_SUCCESS) return hret;
+    if (hret != HG_SUCCESS) return hret;
 
     hret = margo_provider_forward(provider_id, h, NULL);
-    if(hret != HG_SUCCESS) goto finish;
+    if (hret != HG_SUCCESS) goto finish;
 
     hret = margo_get_output(h, &out);
-    if(hret != HG_SUCCESS) goto finish;
+    if (hret != HG_SUCCESS) goto finish;
 
-    if(out) {
+    if (out) {
         size_t len = strlen(out);
-        if(*bufsize >= len + 1) {
+        if (*bufsize >= len + 1) {
             strcpy(buffer, out);
             *bufsize = len + 1;
         } else {
-            if(*bufsize) buffer[0] = 0;
+            if (*bufsize) buffer[0] = 0;
             *bufsize = len + 1;
-            hret = HG_NOMEM;
+            hret     = HG_NOMEM;
             goto finish;
         }
     } else {

--- a/src/margo-identity.c
+++ b/src/margo-identity.c
@@ -1,0 +1,106 @@
+/*
+ * (C) 2023 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#include "margo.h"
+#include "margo-instance.h"
+#include <mercury_proc_string.h>
+#include <string.h>
+#include <stdlib.h>
+
+static void  get_identity(hg_handle_t handle)
+{
+    const struct hg_info* info     = margo_get_info(handle);
+    margo_instance_id     mid      = margo_hg_handle_get_instance(handle);
+    hg_string_t           identity = (hg_string_t)margo_registered_data(mid, info->id);
+    margo_respond(handle, &identity);
+    margo_destroy(handle);
+}
+DEFINE_MARGO_RPC_HANDLER(get_identity)
+
+hg_return_t margo_provider_register_identity(margo_instance_id mid,
+                                             uint16_t provider_id,
+                                             const char* identity)
+{
+    if(!identity) return HG_INVALID_ARG;
+    hg_id_t id = MARGO_REGISTER_PROVIDER(
+        mid, "__identity__", void, hg_string_t, get_identity, provider_id, ABT_POOL_NULL);
+    if(!id) return HG_OTHER_ERROR;
+    char* data = strdup(identity);
+    margo_register_data(mid, id, data, free);
+    return HG_SUCCESS;
+}
+
+hg_return_t margo_provider_deregister_identity(margo_instance_id mid,
+                                               uint16_t provider_id)
+{
+    hg_id_t     id;
+    hg_bool_t   flag = HG_FALSE;
+    hg_return_t hret;
+    hret = margo_provider_registered_name(
+        mid, "__identity__", provider_id, &id, &flag);
+    if(hret != HG_SUCCESS) return hret;
+    if(!flag) return HG_NOENTRY;
+    margo_deregister(mid, id);
+    return HG_SUCCESS;
+}
+
+const char* margo_provider_registered_identity(margo_instance_id mid,
+                                               uint16_t provider_id)
+{
+    hg_id_t     id;
+    hg_bool_t   flag = HG_FALSE;
+    hg_return_t hret;
+    hret = margo_provider_registered_name(
+        mid, "__identity__", provider_id, &id, &flag);
+    if(hret != HG_SUCCESS) return NULL;
+    if(!flag) return NULL;
+    const char* identity = margo_registered_data(mid, id);
+    return identity;
+}
+
+hg_return_t margo_provider_get_identity(margo_instance_id mid,
+                                        hg_addr_t address,
+                                        uint16_t provider_id,
+                                        char* buffer,
+                                        size_t* bufsize)
+{
+    if(!bufsize || !buffer) return HG_INVALID_ARG;
+
+    hg_string_t out  = NULL;
+    hg_handle_t h    = HG_HANDLE_NULL;
+    hg_return_t hret = HG_SUCCESS;
+    hg_id_t     id;
+    hg_bool_t   flag = HG_FALSE;
+
+    hret = margo_create(mid, address, mid->identity_rpc_id, &h);
+    if(hret != HG_SUCCESS) return hret;
+
+    hret = margo_provider_forward(provider_id, h, NULL);
+    if(hret != HG_SUCCESS) goto finish;
+
+    hret = margo_get_output(h, &out);
+    if(hret != HG_SUCCESS) goto finish;
+
+    if(out) {
+        size_t len = strlen(out);
+        if(*bufsize >= len + 1) {
+            strcpy(buffer, out);
+            *bufsize = len + 1;
+        } else {
+            if(*bufsize) buffer[0] = 0;
+            *bufsize = len + 1;
+            hret = HG_NOMEM;
+            goto finish;
+        }
+    } else {
+        *bufsize = 0;
+    }
+
+    margo_free_output(h, &out);
+
+finish:
+    margo_destroy(h);
+    return hret;
+}

--- a/src/margo-identity.c
+++ b/src/margo-identity.c
@@ -11,9 +11,12 @@
 
 static void get_identity(hg_handle_t handle)
 {
-    const struct hg_info* info = margo_get_info(handle);
-    margo_instance_id     mid  = margo_hg_handle_get_instance(handle);
-    hg_string_t identity = (hg_string_t)margo_registered_data(mid, info->id);
+    hg_string_t           identity = NULL;
+    const struct hg_info* info     = margo_get_info(handle);
+    if (!info) goto finish;
+    margo_instance_id mid = margo_hg_handle_get_instance(handle);
+    identity              = (hg_string_t)margo_registered_data(mid, info->id);
+finish:
     margo_respond(handle, &identity);
     margo_destroy(handle);
 }
@@ -72,8 +75,6 @@ hg_return_t margo_provider_get_identity(margo_instance_id mid,
     hg_string_t out  = NULL;
     hg_handle_t h    = HG_HANDLE_NULL;
     hg_return_t hret = HG_SUCCESS;
-    hg_id_t     id;
-    hg_bool_t   flag = HG_FALSE;
 
     hret = margo_create(mid, address, mid->identity_rpc_id, &h);
     if (hret != HG_SUCCESS) return hret;
@@ -93,7 +94,6 @@ hg_return_t margo_provider_get_identity(margo_instance_id mid,
             if (*bufsize) buffer[0] = 0;
             *bufsize = len + 1;
             hret     = HG_NOMEM;
-            goto finish;
         }
     } else {
         *bufsize = 0;

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -5,6 +5,7 @@
  */
 #include <stdbool.h>
 #include <ctype.h>
+#include <mercury_proc_string.h>
 #include <margo.h>
 #include <margo-logging.h>
 #include "margo-instance.h"
@@ -308,6 +309,8 @@ margo_instance_id margo_init_ext(const char*                   address,
     mid->shutdown_rpc_id        = 0;
     mid->enable_remote_shutdown = 0;
 
+    mid->identity_rpc_id = 0;
+
     mid->timer_list = __margo_timer_list_create();
 
     mid->handle_cache_size = handle_cache_size;
@@ -350,6 +353,9 @@ margo_instance_id margo_init_ext(const char*                   address,
 
     mid->shutdown_rpc_id = MARGO_REGISTER(
         mid, "__shutdown__", void, margo_shutdown_out_t, remote_shutdown_ult);
+
+    mid->identity_rpc_id = MARGO_REGISTER(
+        mid, "__identity__", void, hg_string_t, NULL);
 
     MARGO_TRACE(0, "Starting progress loop");
     ret = ABT_thread_create(MARGO_PROGRESS_POOL(mid), __margo_hg_progress_fn,

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -354,8 +354,8 @@ margo_instance_id margo_init_ext(const char*                   address,
     mid->shutdown_rpc_id = MARGO_REGISTER(
         mid, "__shutdown__", void, margo_shutdown_out_t, remote_shutdown_ult);
 
-    mid->identity_rpc_id = MARGO_REGISTER(
-        mid, "__identity__", void, hg_string_t, NULL);
+    mid->identity_rpc_id
+        = MARGO_REGISTER(mid, "__identity__", void, hg_string_t, NULL);
 
     MARGO_TRACE(0, "Starting progress loop");
     ret = ABT_thread_create(MARGO_PROGRESS_POOL(mid), __margo_hg_progress_fn,

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -129,8 +129,7 @@ struct margo_instance {
 
 #define MARGO_RPC_POOL(mid) (mid)->abt.pools[mid->rpc_pool_idx].pool
 
-typedef enum margo_request_kind
-{
+typedef enum margo_request_kind {
     MARGO_REQ_EVENTUAL,
     MARGO_REQ_CALLBACK
 } margo_request_kind;
@@ -158,10 +157,10 @@ struct margo_request_struct {
 struct margo_rpc_data {
     margo_instance_id mid;
     _Atomic(ABT_pool) pool;
-    char*        rpc_name;
-    hg_proc_cb_t in_proc_cb;  /* user-provided input proc */
-    hg_proc_cb_t out_proc_cb; /* user-provided output proc */
-    void*        user_data;
+    char*             rpc_name;
+    hg_proc_cb_t      in_proc_cb;  /* user-provided input proc */
+    hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
+    void*             user_data;
     void (*user_free_callback)(void*);
 };
 

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -95,6 +95,9 @@ struct margo_instance {
     hg_id_t shutdown_rpc_id;
     bool    enable_remote_shutdown;
 
+    /* control logic for provider identity */
+    hg_id_t identity_rpc_id;
+
     /* timer data */
     struct margo_timer_list* timer_list;
 

--- a/tests/unit-tests/Makefile.subdir
+++ b/tests/unit-tests/Makefile.subdir
@@ -3,6 +3,7 @@ if BUILD_TESTS
 check_PROGRAMS += \
  tests/unit-tests/margo-addr \
  tests/unit-tests/margo-init \
+ tests/unit-tests/margo-identity \
  tests/unit-tests/margo-config \
  tests/unit-tests/margo-elasticity \
  tests/unit-tests/margo-pool \
@@ -21,6 +22,7 @@ check_PROGRAMS += \
 TESTS += \
  tests/unit-tests/margo-addr \
  tests/unit-tests/margo-init \
+ tests/unit-tests/margo-identity \
  tests/unit-tests/margo-config \
  tests/unit-tests/margo-elasticity \
  tests/unit-tests/margo-pool \
@@ -44,6 +46,11 @@ tests_unit_tests_margo_addr_SOURCES = \
 tests_unit_tests_margo_init_SOURCES = \
  tests/unit-tests/munit/munit.c \
  tests/unit-tests/margo-init.c \
+ tests/unit-tests/helper-server.c
+
+tests_unit_tests_margo_identity_SOURCES = \
+ tests/unit-tests/munit/munit.c \
+ tests/unit-tests/margo-identity.c \
  tests/unit-tests/helper-server.c
 
 tests_unit_tests_margo_config_SOURCES = \

--- a/tests/unit-tests/margo-identity.c
+++ b/tests/unit-tests/margo-identity.c
@@ -1,0 +1,99 @@
+
+#include <margo.h>
+#include "helper-server.h"
+#include "munit/munit.h"
+
+struct test_context {
+    margo_instance_id mid;
+    hg_addr_t         address;
+};
+
+static void* test_context_setup(const MunitParameter params[], void* user_data)
+{
+    (void) params;
+    (void) user_data;
+    struct test_context* ctx = calloc(1, sizeof(*ctx));
+    ctx->mid = margo_init("na+sm", MARGO_SERVER_MODE, 0, 0);
+    munit_assert_not_null(ctx->mid);
+
+    margo_addr_self(ctx->mid, &ctx->address);
+
+    return ctx;
+}
+
+static void test_context_tear_down(void *data)
+{
+    struct test_context *ctx = (struct test_context*)data;
+    margo_addr_free(ctx->mid, ctx->address);
+    margo_finalize(ctx->mid);
+    free(ctx);
+}
+
+static MunitResult test_identity(const MunitParameter params[], void* data)
+{
+    struct test_context* ctx = (struct test_context*)data;
+    hg_return_t hret;
+
+    const char* identity = margo_provider_registered_identity(ctx->mid, 42);
+    munit_assert_null(identity);
+
+    char buffer[256];
+    size_t bufsize = 256;
+
+    hret = margo_provider_get_identity(ctx->mid, ctx->address, 42, NULL, &bufsize);
+    munit_assert_int(hret, ==, HG_INVALID_ARG);
+
+    hret = margo_provider_get_identity(ctx->mid, ctx->address, 42, buffer, NULL);
+    munit_assert_int(hret, ==, HG_INVALID_ARG);
+
+    hret = margo_provider_get_identity(ctx->mid, ctx->address, 42, buffer, &bufsize);
+    munit_assert_int(hret, ==, HG_NOENTRY);
+
+    hret = margo_provider_register_identity(ctx->mid, 42, "something");
+    munit_assert_int(hret, ==, HG_SUCCESS);
+
+    hret = margo_provider_get_identity(ctx->mid, ctx->address, 42, buffer, &bufsize);
+    munit_assert_int(hret, ==, HG_SUCCESS);
+    munit_assert_string_equal(buffer, "something");
+    munit_assert_size(bufsize, == , strlen("something")+1);
+
+    identity = margo_provider_registered_identity(ctx->mid, 42);
+    munit_assert_not_null(identity);
+    munit_assert_string_equal(identity, "something");
+
+    bufsize = 4;
+    hret = margo_provider_get_identity(ctx->mid, ctx->address, 42, buffer, &bufsize);
+    munit_assert_int(hret, ==, HG_NOMEM);
+    munit_assert_size(bufsize, == , strlen("something")+1);
+
+    hret = margo_provider_deregister_identity(ctx->mid, 42);
+    munit_assert_int(hret, ==, HG_SUCCESS);
+
+    identity = margo_provider_registered_identity(ctx->mid, 42);
+    munit_assert_null(identity);
+
+    bufsize = 256;
+    hret = margo_provider_get_identity(ctx->mid, ctx->address, 42, buffer, &bufsize);
+    munit_assert_int(hret, ==, HG_NOENTRY);
+
+    return MUNIT_OK;
+}
+
+static MunitParameterEnum test_params[] = {
+    { NULL, NULL }
+};
+
+static MunitTest tests[] = {
+    { "/identity", test_identity, test_context_setup, test_context_tear_down, MUNIT_TEST_OPTION_NONE, test_params},
+    { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};
+
+static const MunitSuite test_suite = {
+    "/margo", tests, NULL, 1, MUNIT_SUITE_OPTION_NONE
+};
+
+
+int main(int argc, char **argv)
+{
+    return munit_suite_main(&test_suite, NULL, argc, argv);
+}

--- a/tests/unit-tests/margo-monitoring.c
+++ b/tests/unit-tests/margo-monitoring.c
@@ -241,9 +241,9 @@ static MunitResult test_custom_monitoring(const MunitParameter params[],
 
     hg_id_t echo_id = MARGO_REGISTER(mid, "custom_echo", echo_in_t, hg_string_t, custom_echo_ult);
     munit_assert_uint64(echo_id, !=, 0);
-    /* note: because of the __shutdown__ RPC, the count will be at 2 */
-    munit_assert_int(monitor_data.call_count[MARGO_MONITOR_ON_REGISTER].fn_start, ==, 2);
-    munit_assert_int(monitor_data.call_count[MARGO_MONITOR_ON_REGISTER].fn_end, ==, 2);
+    /* note: because of the __shutdown__ and __identity__ RPCs, the count will be at 3 */
+    munit_assert_int(monitor_data.call_count[MARGO_MONITOR_ON_REGISTER].fn_start, ==, 3);
+    munit_assert_int(monitor_data.call_count[MARGO_MONITOR_ON_REGISTER].fn_end, ==, 3);
 
     margo_thread_sleep(mid, 1);
     munit_assert_int(monitor_data.call_count[MARGO_MONITOR_ON_SLEEP].fn_start, ==, 1);


### PR DESCRIPTION
Adds an API to associate a provider name with a provider ID, making querying such a name possible remotely.

Note: because "name" is used often to refer to RPC name (e.g. margo_register_name), I decided to use the term "identity" instead for provider. In practice, we will in fact use it to register the type of provider ("yokan", "warabi", etc.) rather than a unique name, so an "identity" is more suitable.