### PR TITLE
Fix monitoring when adding pools

### DIFF
--- a/include/margo-monitoring.h
+++ b/include/margo-monitoring.h
@@ -135,34 +135,38 @@ typedef enum margo_monitor_event_t
 } margo_monitor_event_t;
 
 /* clang-format off */
-typedef struct margo_monitor_progress_args*      margo_monitor_progress_args_t;
-typedef struct margo_monitor_trigger_args*       margo_monitor_trigger_args_t;
-typedef struct margo_monitor_register_args*      margo_monitor_register_args_t;
-typedef struct margo_monitor_deregister_args*    margo_monitor_deregister_args_t;
-typedef struct margo_monitor_lookup_args*        margo_monitor_lookup_args_t;
-typedef struct margo_monitor_create_args*        margo_monitor_create_args_t;
-typedef struct margo_monitor_forward_args*       margo_monitor_forward_args_t;
-typedef struct margo_monitor_cb_args*            margo_monitor_forward_cb_args_t;
-typedef struct margo_monitor_respond_args*       margo_monitor_respond_args_t;
-typedef struct margo_monitor_cb_args*            margo_monitor_respond_cb_args_t;
-typedef struct margo_monitor_destroy_args*       margo_monitor_destroy_args_t;
-typedef struct margo_monitor_bulk_create_args*   margo_monitor_bulk_create_args_t;
-typedef struct margo_monitor_bulk_transfer_args* margo_monitor_bulk_transfer_args_t;
-typedef struct margo_monitor_cb_args*            margo_monitor_bulk_transfer_cb_args_t;
-typedef struct margo_monitor_bulk_free_args*     margo_monitor_bulk_free_args_t;
-typedef struct margo_monitor_rpc_handler_args*   margo_monitor_rpc_handler_args_t;
-typedef struct margo_monitor_rpc_ult_args*       margo_monitor_rpc_ult_args_t;
-typedef struct margo_monitor_wait_args*          margo_monitor_wait_args_t;
-typedef struct margo_monitor_sleep_args*         margo_monitor_sleep_args_t;
-typedef struct margo_monitor_set_input_args*     margo_monitor_set_input_args_t;
-typedef struct margo_monitor_set_output_args*    margo_monitor_set_output_args_t;
-typedef struct margo_monitor_get_input_args*     margo_monitor_get_input_args_t;
-typedef struct margo_monitor_get_output_args*    margo_monitor_get_output_args_t;
-typedef struct margo_monitor_free_input_args*    margo_monitor_free_input_args_t;
-typedef struct margo_monitor_free_output_args*   margo_monitor_free_output_args_t;
-typedef struct margo_monitor_prefinalize_args*   margo_monitor_prefinalize_args_t;
-typedef struct margo_monitor_finalize_args*      margo_monitor_finalize_args_t;
-typedef const char*                              margo_monitor_user_args_t;
+typedef struct margo_monitor_progress_args*       margo_monitor_progress_args_t;
+typedef struct margo_monitor_trigger_args*        margo_monitor_trigger_args_t;
+typedef struct margo_monitor_register_args*       margo_monitor_register_args_t;
+typedef struct margo_monitor_deregister_args*     margo_monitor_deregister_args_t;
+typedef struct margo_monitor_lookup_args*         margo_monitor_lookup_args_t;
+typedef struct margo_monitor_create_args*         margo_monitor_create_args_t;
+typedef struct margo_monitor_forward_args*        margo_monitor_forward_args_t;
+typedef struct margo_monitor_cb_args*             margo_monitor_forward_cb_args_t;
+typedef struct margo_monitor_respond_args*        margo_monitor_respond_args_t;
+typedef struct margo_monitor_cb_args*             margo_monitor_respond_cb_args_t;
+typedef struct margo_monitor_destroy_args*        margo_monitor_destroy_args_t;
+typedef struct margo_monitor_bulk_create_args*    margo_monitor_bulk_create_args_t;
+typedef struct margo_monitor_bulk_transfer_args*  margo_monitor_bulk_transfer_args_t;
+typedef struct margo_monitor_cb_args*             margo_monitor_bulk_transfer_cb_args_t;
+typedef struct margo_monitor_bulk_free_args*      margo_monitor_bulk_free_args_t;
+typedef struct margo_monitor_rpc_handler_args*    margo_monitor_rpc_handler_args_t;
+typedef struct margo_monitor_rpc_ult_args*        margo_monitor_rpc_ult_args_t;
+typedef struct margo_monitor_wait_args*           margo_monitor_wait_args_t;
+typedef struct margo_monitor_sleep_args*          margo_monitor_sleep_args_t;
+typedef struct margo_monitor_set_input_args*      margo_monitor_set_input_args_t;
+typedef struct margo_monitor_set_output_args*     margo_monitor_set_output_args_t;
+typedef struct margo_monitor_get_input_args*      margo_monitor_get_input_args_t;
+typedef struct margo_monitor_get_output_args*     margo_monitor_get_output_args_t;
+typedef struct margo_monitor_free_input_args*     margo_monitor_free_input_args_t;
+typedef struct margo_monitor_free_output_args*    margo_monitor_free_output_args_t;
+typedef struct margo_monitor_prefinalize_args*    margo_monitor_prefinalize_args_t;
+typedef struct margo_monitor_finalize_args*       margo_monitor_finalize_args_t;
+typedef struct margo_monitor_add_pool_args*       margo_monitor_add_pool_args_t;
+typedef struct margo_monitor_remove_pool_args*    margo_monitor_remove_pool_args_t;
+typedef struct margo_monitor_add_xstream_args*    margo_monitor_add_xstream_args_t;
+typedef struct margo_monitor_remove_xstream_args* margo_monitor_remove_xstream_args_t;
+typedef const char*                               margo_monitor_user_args_t;
 /* clang-format on */
 
 /* clang-format off */
@@ -194,6 +198,10 @@ typedef const char*                              margo_monitor_user_args_t;
     X(FREE_OUTPUT,      free_output)      \
     X(PREFINALIZE,      prefinalize)      \
     X(FINALIZE,         finalize)         \
+    X(ADD_POOL,         add_pool)         \
+    X(REMOVE_POOL,      remove_pool)      \
+    X(ADD_XSTREAM,      add_xstream)      \
+    X(REMOVE_XSTREAM,   remove_xstream)   \
     X(USER,             user)
 /* clang-format on */
 
@@ -451,6 +459,36 @@ struct margo_monitor_cb_args {
     /* input */
     const struct hg_cb_info* info;
     margo_request            request;
+    /* output */
+    hg_return_t ret;
+};
+
+struct margo_monitor_add_pool_args {
+    margo_monitor_data_t uctx;
+    /* output */
+    const struct margo_pool_info* info;
+    hg_return_t                   ret;
+};
+
+struct margo_monitor_remove_pool_args {
+    margo_monitor_data_t uctx;
+    /* input/output */
+    const struct margo_pool_info* info;
+    /* output */
+    hg_return_t ret;
+};
+
+struct margo_monitor_add_xstream_args {
+    margo_monitor_data_t uctx;
+    /* output */
+    const struct margo_xstream_info* info;
+    hg_return_t                      ret;
+};
+
+struct margo_monitor_remove_xstream_args {
+    margo_monitor_data_t uctx;
+    /* input/output */
+    const struct margo_xstream_info* info;
     /* output */
     hg_return_t ret;
 };

--- a/src/margo-default-monitoring.c
+++ b/src/margo-default-monitoring.c
@@ -1471,6 +1471,11 @@ __MONITOR_FN_EMPTY(prefinalize)
 __MONITOR_FN_EMPTY(finalize)
 __MONITOR_FN_EMPTY(user)
 
+__MONITOR_FN_EMPTY(add_pool)
+__MONITOR_FN_EMPTY(remove_pool)
+__MONITOR_FN_EMPTY(add_xstream)
+__MONITOR_FN_EMPTY(remove_xstream)
+
 static hg_return_t __margo_default_monitor_dump(void*                 uargs,
                                                 margo_monitor_dump_fn dump_fn,
                                                 void*                 dump_args,


### PR DESCRIPTION
This PR fixes a bug that happens if we add a pool when monitoring (in particular time series) is enabled. The current problem is that because there is no time series structure allocated for the new pool, the default monitoring system will access an array out of range, causing a segfault.

To solve this problem, this PR makes the following changes:
- It adds monitoring callbacks invoked when pools and xstreams are added and removed, to give a chance for the monitoring framework (whether default or custom) to react to such a change (e.g. by allocating/deallocating the proper data structures);
- It implements these callbacks for the default monitoring framework, allocating and moving the the time series as appropriate when a pool is added/removed.