### PR TITLE
Add the possibility to specify logging level via an environment variable

### DIFF
--- a/src/margo-logging.c
+++ b/src/margo-logging.c
@@ -7,7 +7,8 @@
 #include "margo-instance.h"
 #include <margo-logging.h>
 
-static margo_log_level global_log_level = MARGO_LOG_WARNING;
+static const char*     global_log_level_env = NULL;
+static margo_log_level global_log_level     = MARGO_LOG_WARNING;
 
 static void __margo_log_trace(void* uargs, const char* str)
 {
@@ -53,11 +54,66 @@ static struct margo_logger global_logger = {.uargs    = NULL,
                                             .error    = __margo_log_error,
                                             .critical = __margo_log_critical};
 
+static margo_log_level log_level_from_string(const char* level)
+{
+    if (!level) return -1;
+    if (strcmp(level, "trace") == 0) return MARGO_LOG_TRACE;
+    if (strcmp(level, "debug") == 0) return MARGO_LOG_DEBUG;
+    if (strcmp(level, "info") == 0) return MARGO_LOG_INFO;
+    if (strcmp(level, "warning") == 0) return MARGO_LOG_WARNING;
+    if (strcmp(level, "error") == 0) return MARGO_LOG_ERROR;
+    if (strcmp(level, "critical") == 0)
+        return MARGO_LOG_CRITICAL;
+    else {
+        fprintf(stderr, "[warning] unknown log level \"%s\"", level);
+        return -1;
+    }
+}
+
+static const char* log_level_to_string(margo_log_level level)
+{
+    switch (level) {
+    case MARGO_LOG_TRACE:
+        return "trace";
+    case MARGO_LOG_DEBUG:
+        return "debug";
+    case MARGO_LOG_INFO:
+        return "info";
+    case MARGO_LOG_WARNING:
+        return "warning";
+    case MARGO_LOG_ERROR:
+        return "error";
+    case MARGO_LOG_CRITICAL:
+        return "critical";
+    default:
+        return "";
+    }
+}
+
+static inline void set_global_log_level_from_env()
+{
+    /* this function will be called the first time the global log level is
+     * needed */
+    if (!global_log_level_env) {
+        global_log_level_env = getenv("MARGO_LOG_LEVEL");
+        int l                = log_level_from_string(global_log_level_env);
+        if (l == -1) {
+            fprintf(stderr,
+                    "[warning] unknown log level \"%s\" in MARGO_LOG_LEVEL,"
+                    " defaulting to \"warning\"",
+                    global_log_level_env);
+            global_log_level_env = log_level_to_string(global_log_level);
+        }
+        global_log_level = log_level_from_string(global_log_level_env);
+    }
+}
+
 #define DEFINE_LOG_FN(__name__, __level__, __LEVEL__)                        \
     void __name__(margo_instance_id mid, const char* fmt, ...)               \
     {                                                                        \
         static const margo_log_level function_level = MARGO_LOG_##__LEVEL__; \
-        margo_log_level              logger_level                            \
+        set_global_log_level_from_env();                                     \
+        margo_log_level logger_level                                         \
             = mid ? mid->log_level : global_log_level;                       \
         if (logger_level > function_level) return;                           \
         va_list args1;                                                       \
@@ -70,7 +126,7 @@ static struct margo_logger global_logger = {.uargs    = NULL,
         vsnprintf(buf, msg_size + 1, fmt, args2);                            \
         if (mid && mid->logger.__level__)                                    \
             mid->logger.__level__(mid->logger.uargs, buf);                   \
-        else if (global_logger.__level__)                                    \
+        else if (!mid && global_logger.__level__)                            \
             global_logger.__level__(global_logger.uargs, buf);               \
         va_end(args2);                                                       \
     }
@@ -84,6 +140,7 @@ DEFINE_LOG_FN(margo_critical, critical, CRITICAL)
 
 int margo_set_logger(margo_instance_id mid, const struct margo_logger* logger)
 {
+    set_global_log_level_from_env();
     if (!logger) {
         mid->logger.uargs    = NULL;
         mid->logger.trace    = __margo_log_trace;
@@ -92,10 +149,10 @@ int margo_set_logger(margo_instance_id mid, const struct margo_logger* logger)
         mid->logger.warning  = __margo_log_warning;
         mid->logger.error    = __margo_log_error;
         mid->logger.critical = __margo_log_critical;
-        mid->log_level       = MARGO_LOG_WARNING;
     } else {
         mid->logger = *logger;
     }
+    mid->log_level = global_log_level;
     return 0;
 }
 
@@ -116,7 +173,6 @@ int margo_set_global_logger(const struct margo_logger* logger)
         global_logger.warning  = __margo_log_warning;
         global_logger.error    = __margo_log_error;
         global_logger.critical = __margo_log_critical;
-        global_log_level       = MARGO_LOG_WARNING;
     } else {
         global_logger = *logger;
     }
@@ -126,6 +182,7 @@ int margo_set_global_logger(const struct margo_logger* logger)
 int margo_set_global_log_level(margo_log_level level)
 {
     if (level < 0 || level > MARGO_LOG_CRITICAL) return -1;
-    global_log_level = level;
+    global_log_level     = level;
+    global_log_level_env = log_level_to_string(level);
     return 0;
 }


### PR DESCRIPTION
This PR addresses https://github.com/mochi-hpc/mochi-margo/issues/275. It adds the possibility to set `MARGO_LOG_LEVEL` to one of the levels ("trace", "debug", "info", "warning", "error", "critical"). This variable applies to the requested log level for the global logger. The PR also makes any instance-specific logger inherit the level from the global logger at creation time, instead of being set to "warning".