### PR TITLE
don't print rpc_name pointer after handler exec

### DIFF
--- a/include/margo.h
+++ b/include/margo.h
@@ -2036,8 +2036,7 @@ hg_return_t _handler_for_NULL(hg_handle_t);
     margo_trace(__mid, "Starting RPC %s (handle = %p)", __rpc_name,           \
                 (void*)handle);                                               \
     __name(handle);                                                           \
-    margo_trace(__mid, "RPC %s completed (handle = %p)", __rpc_name,          \
-                (void*)handle);                                               \
+    margo_trace(__mid, "RPC completed (handle = %p)", (void*)handle);         \
     __margo_internal_post_wrapper_hooks(__mid, &__monitoring_args);
 
 #define __MARGO_INTERNAL_RPC_WRAPPER(__name)       \


### PR DESCRIPTION
- bug fix: the rpc_name is an internal pointer that may not necessarily be valid after completion of an RPC handler if the process unregisters an RPC fast enough

Alternatively we could strdup the rpc name to make sure the RPC wrapper has a copy that stays in scope, but I don't think the information is worth the memory allocation.  The handle pointer value is sufficient to map back to the preceding trace message if needed.