### PR TITLE
add spindown parameter

### DIFF
--- a/src/margo-config.c
+++ b/src/margo-config.c
@@ -53,6 +53,10 @@ char* margo_get_config_opt(margo_instance_id mid, int options)
     json_object_object_add_ex(
         root, "progress_timeout_ub_msec",
         json_object_new_uint64(mid->hg_progress_timeout_ub), flags);
+    // progress_spindown_msec
+    json_object_object_add_ex(
+        root, "progress_spindown_msec",
+        json_object_new_uint64(mid->hg_progress_spindown_msec), flags);
     // handle_cache_size
     json_object_object_add_ex(root, "handle_cache_size",
                               json_object_new_uint64(mid->handle_cache_size),

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -1979,7 +1979,7 @@ void __margo_hg_progress_fn(void* foo)
              * iteration.  See if spindown time has elapsed yet.
              */
             if ((spin_start_ts - ABT_get_wtime())
-                < (double)mid->hg_progress_spindown_ms) {
+                < (double)mid->hg_progress_spindown_msec) {
                 /* We are still in the spindown window; continue spinning
                  * regardless of current conditions.
                  */

--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -300,6 +300,7 @@ margo_instance_id margo_init_ext(const char*                   address,
     mid->hg_progress_tid           = ABT_THREAD_NULL;
     mid->hg_progress_shutdown_flag = 0;
     mid->hg_progress_timeout_ub    = progress_timeout_ub;
+    mid->hg_progress_spindown_ms   = 1; /* TODO: temporarily hard coded */
 
     mid->num_registered_rpcs = 0;
     mid->registered_rpcs     = NULL;

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -71,6 +71,7 @@ struct margo_instance {
     ABT_thread       hg_progress_tid;
     _Atomic int      hg_progress_shutdown_flag;
     _Atomic unsigned hg_progress_timeout_ub;
+    _Atomic unsigned hg_progress_spindown_ms;
 
     uint16_t num_registered_rpcs; /* number of registered rpc's by all providers
                                      on this instance */
@@ -130,8 +131,7 @@ struct margo_instance {
 
 #define MARGO_RPC_POOL(mid) (mid)->abt.pools[mid->rpc_pool_idx].pool
 
-typedef enum margo_request_kind
-{
+typedef enum margo_request_kind {
     MARGO_REQ_EVENTUAL,
     MARGO_REQ_CALLBACK
 } margo_request_kind;
@@ -159,10 +159,10 @@ struct margo_request_struct {
 struct margo_rpc_data {
     margo_instance_id mid;
     _Atomic(ABT_pool) pool;
-    char*        rpc_name;
-    hg_proc_cb_t in_proc_cb;  /* user-provided input proc */
-    hg_proc_cb_t out_proc_cb; /* user-provided output proc */
-    void*        user_data;
+    char*             rpc_name;
+    hg_proc_cb_t      in_proc_cb;  /* user-provided input proc */
+    hg_proc_cb_t      out_proc_cb; /* user-provided output proc */
+    void*             user_data;
     void (*user_free_callback)(void*);
 };
 

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -71,7 +71,7 @@ struct margo_instance {
     ABT_thread       hg_progress_tid;
     _Atomic int      hg_progress_shutdown_flag;
     _Atomic unsigned hg_progress_timeout_ub;
-    _Atomic unsigned hg_progress_spindown_ms;
+    _Atomic unsigned hg_progress_spindown_msec;
 
     uint16_t num_registered_rpcs; /* number of registered rpc's by all providers
                                      on this instance */

--- a/tests/unit-tests/test-configs.json
+++ b/tests/unit-tests/test-configs.json
@@ -2,27 +2,27 @@
     "empty": {
         "pass": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/hide_external": {
         "pass": true,
         "hide_external": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks": {
         "pass": true,
         "input": {"argobots":{"abt_mem_max_num_stacks": 12}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":12,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":12,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks/abt_thread_stacksize/abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {"argobots":{"abt_mem_max_num_stacks": 12, "abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks/env": {
@@ -31,7 +31,7 @@
             "ABT_MEM_MAX_NUM_STACKS": "16"
         },
         "input": {"argobots":{"abt_mem_max_num_stacks": 12}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":16,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":16,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_mem_max_num_stacks_must_be_an_integer": {
@@ -42,7 +42,7 @@
     "abt_thread_stacksize": {
         "pass": true,
         "input": {"argobots":{"abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000000,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000000,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_thread_stacksize/env": {
@@ -51,7 +51,7 @@
             "ABT_THREAD_STACKSIZE": "2000002"
         },
         "input": {"argobots":{"abt_thread_stacksize": 2000000}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000002,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2000002,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "abt_thread_stacksize_must_be_an_integer": {
@@ -62,27 +62,27 @@
     "use_progress_thread=true": {
         "pass": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "use_progress_thread=true/use_names": {
         "pass": true,
         "use_names": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":["__primary__"]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":["__pool_1__"]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":"__pool_1__","rpc_pool":"__primary__"}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":["__primary__"]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":["__pool_1__"]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":"__pool_1__","rpc_pool":"__primary__"}
     },
 
     "use_progress_thread=false": {
         "pass": true,
         "input": {"use_progress_thread": false},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/with_abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "empty/with_abt_init/hide_external": {
@@ -90,21 +90,21 @@
         "abt_init": true,
         "hide_external": true,
         "input": {},
-        "output": {"argobots":{"pools":[],"xstreams":[],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[],"xstreams":[],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "use_progress_thread=true/with_abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {"use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "use_progress_thread=false/with_abt_init": {
         "pass": true,
         "abt_init": true,
         "input": {"use_progress_thread": false},
-        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"external","name":"__primary__"}],"xstreams":[{"scheduler":{"type":"external","pools":[0]},"name":"__primary__"}],"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "use_progress_thead=string": {
@@ -115,25 +115,25 @@
     "rpc_thread_count=-1": {
         "pass": true,
         "input": {"rpc_thread_count": -1},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "rpc_thread_count=0": {
         "pass": true,
         "input": {"rpc_thread_count": 0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "rpc_thread_count=1": {
         "pass": true,
         "input": {"rpc_thread_count": 1},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "rpc_thread_count=2": {
         "pass": true,
         "input": {"rpc_thread_count": 2},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "rpc_thread_count=string": {
@@ -144,31 +144,31 @@
     "rpc_thread_count=-1/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": -1, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "rpc_thread_count=0/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 0, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_thread_count=1/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 1, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_2__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
     },
 
     "rpc_thread_count=2/use_progress_thread=true": {
         "pass": true,
         "input": {"rpc_thread_count": 2, "use_progress_thread": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_2__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_3__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_1__","access":"mpmc"},{"kind":"fifo_wait","name":"__pool_2__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__xstream_1__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_2__"},{"scheduler":{"type":"basic_wait","pools":[2]},"name":"__xstream_3__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":2}
     },
 
     "valid_pool_kinds_and_access": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"fifo_pool","kind":"fifo","access":"private"},{"name":"fifo_wait_pool","kind":"fifo_wait","access":"mpmc"},{"name":"prio_wait_pool","kind":"prio_wait","access":"spsc"},{"name":"fifo_pool_2","kind":"fifo","access":"mpsc"},{"name":"fifo_pool_3","kind":"fifo","access":"spmc"}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"fifo_pool","access":"private"},{"kind":"fifo_wait","name":"fifo_wait_pool","access":"mpmc"},{"kind":"prio_wait","name":"prio_wait_pool","access":"spsc"},{"kind":"fifo","name":"fifo_pool_2","access":"mpsc"},{"kind":"fifo","name":"fifo_pool_3","access":"spmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[5]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":5,"rpc_pool":5}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"fifo_pool","access":"private"},{"kind":"fifo_wait","name":"fifo_wait_pool","access":"mpmc"},{"kind":"prio_wait","name":"prio_wait_pool","access":"spsc"},{"kind":"fifo","name":"fifo_pool_2","access":"mpsc"},{"kind":"fifo","name":"fifo_pool_3","access":"spmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[5]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":5,"rpc_pool":5}
     },
 
     "argobots_should_be_an_object": {
@@ -289,7 +289,7 @@
     "xstreams_cpubind": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"cpubind":0,"scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "xstreams_cpubind_should_be_an_integer": {
@@ -300,7 +300,7 @@
     "xstreams_affinity": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"affinity":[0,1],"scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":1}
     },
 
     "xstreams_affinity_should_be_an_array": {
@@ -361,19 +361,19 @@
     "progress_pool_string": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"my_pool"}],"xstreams":[{"scheduler":{"pools":["my_pool"]}}]},"progress_pool":"my_pool"},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "progress_pool_integer": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"progress_pool":0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "use_progress_thread_is_ignored": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"progress_pool":0, "use_progress_thread":false},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":1}
     },
 
     "progress_pool_should_be_string_or_integer": {
@@ -394,19 +394,19 @@
     "rpc_pool_string": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"my_pool"}],"xstreams":[{"scheduler":{"pools":["my_pool"]}}]},"rpc_pool":"my_pool"},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"my_pool","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_pool_integer": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"rpc_pool":0},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_thread_count_is_ignored": {
         "pass": true,
         "input": {"argobots":{"pools":[{}],"xstreams":[{"scheduler":{"pools":[0]}}]},"rpc_pool":0,"rpc_thread_count":4},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__pool_0__","access":"mpmc"},{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__xstream_0__"},{"scheduler":{"type":"basic_wait","pools":[1]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":1,"rpc_pool":0}
     },
 
     "rpc_pool_should_be_string_or_integer": {
@@ -427,13 +427,13 @@
     "primary_pool": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "primary_xstream": {
         "pass": true,
         "input": {"argobots":{"pools":[{"name":"__primary__","kind":"fifo"}],"xstreams":[{"name":"__primary__","scheduler":{"pools":[0]}}]}},
-        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":false,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     },
 
     "primary_xstream_without_scheduler": {
@@ -461,6 +461,6 @@
     "enable_abt_profiling": {
         "pass": true,
         "input": {"enable_abt_profiling": true},
-        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":true,"progress_timeout_ub_msec":100,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
+        "output": {"argobots":{"pools":[{"kind":"fifo_wait","name":"__primary__","access":"mpmc"}],"xstreams":[{"scheduler":{"type":"basic_wait","pools":[0]},"name":"__primary__"}],"abt_mem_max_num_stacks":8,"abt_thread_stacksize":2097152,"profiling_dir":"."},"enable_abt_profiling":true,"progress_timeout_ub_msec":100,"progress_spindown_msec":10,"handle_cache_size":32,"progress_pool":0,"rpc_pool":0}
     }
 }


### PR DESCRIPTION
This PR makes it so that once Margo starts to busy spin (because of in flight RPCs or active ULTs in the progress pool) , it will continue to do so for a brief, configurable period of time.

The intent is to make Margo slightly less aggressive about entering an idle mode.  It should improve performance particularly for sequential workloads that have small rtt gaps between operations.

Need to performance test before merging but I want to go ahead and open a PR so that it can to through github CI checks.