### PR TITLE
Using ULT stack to store RPC lineage

### DIFF
--- a/src/margo-init.c
+++ b/src/margo-init.c
@@ -330,10 +330,6 @@ margo_instance_id margo_init_ext(const char*                   address,
     hret                   = __margo_handle_cache_init(mid, handle_cache_size);
     if (hret != HG_SUCCESS) goto error;
 
-    // create current_rpc_id_key ABT_key
-    ret = ABT_key_create(NULL, &(mid->current_rpc_id_key));
-    if (ret != ABT_SUCCESS) goto error;
-
     // set logger
     margo_set_logger(mid, args.logger);
 
@@ -386,7 +382,6 @@ error:
         ABT_mutex_free(&mid->finalize_mutex);
         ABT_cond_free(&mid->finalize_cond);
         ABT_mutex_free(&mid->pending_operations_mtx);
-        if (mid->current_rpc_id_key) ABT_key_free(&(mid->current_rpc_id_key));
         free(mid);
     }
     __margo_hg_destroy(&hg);

--- a/src/margo-instance.h
+++ b/src/margo-instance.h
@@ -128,9 +128,6 @@ struct margo_instance {
     _Atomic uint64_t num_progress_calls;
     _Atomic uint64_t num_trigger_calls;
 
-    /* callpath tracking */
-    ABT_key current_rpc_id_key;
-
     /* optional diagnostics data tracking */
     int abt_profiling_enabled;
 };

--- a/src/margo-rpc-lineage.h
+++ b/src/margo-rpc-lineage.h
@@ -1,0 +1,55 @@
+/*
+ * (C) 2024 The University of Chicago
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+#ifndef __MARGO_ABT_KEY_H
+#define __MARGO_ABT_KEY_H
+#include <assert.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <abt.h>
+#include <mercury.h>
+
+#define __MARGO_LINEAGE_COMMON                                    \
+    static const char* magic  = "matthieu";                       \
+    ABT_thread_attr attr      = ABT_THREAD_ATTR_NULL;             \
+    ABT_thread      ult       = ABT_THREAD_NULL;                  \
+    void*           stackaddr = NULL;                             \
+    size_t          stacksize = 0;                                \
+    int             ret;                                          \
+    ret = ABT_thread_self(&ult);                                  \
+    if(ret != ABT_SUCCESS) return ret;                            \
+    ret = ABT_thread_get_attr(ult, &attr);                        \
+    if(ret != ABT_SUCCESS) return ret;                            \
+    ret = ABT_thread_attr_get_stack(attr, &stackaddr, &stacksize);\
+    if(ret != ABT_SUCCESS) return ret;                            \
+    if(!stackaddr || !stacksize) return ABT_ERR_KEY;              \
+    char* stackend = (char*)stackaddr + stacksize
+
+static inline int margo_lineage_set(hg_id_t current_rpc_id) {
+    __MARGO_LINEAGE_COMMON;
+    memcpy(stackend - 8 - sizeof(current_rpc_id), magic, 8);
+    memcpy(stackend - 8, &current_rpc_id, sizeof(current_rpc_id));
+    return ABT_SUCCESS;
+}
+
+static inline int margo_lineage_erase() {
+    __MARGO_LINEAGE_COMMON;
+    memset(stackend - 8 - sizeof(hg_id_t), 0, 8 + sizeof(hg_id_t));
+    return ABT_SUCCESS;
+}
+
+static inline int margo_lineage_get(hg_id_t* current_rpc_id) {
+    __MARGO_LINEAGE_COMMON;
+    if(memcmp(stackend - 8 - sizeof(current_rpc_id), magic, 8) != 0)
+        return ABT_ERR_KEY;
+    memcpy(current_rpc_id, stackend - 8, sizeof(*current_rpc_id));
+    return ABT_SUCCESS;
+}
+
+#undef __MARGO_LINEAGE_COMMON
+
+#endif


### PR DESCRIPTION
@carns This PR is an alternative to disabling `ABT_keys` for lineage tracking. It tries to solve the performance problem by using the end of a ULT's stack to write the current RPC ID. I'm also writing a magic number before it so we can check if the RPC ID has been set (rather than getting garbage), and these values are wiped at the end of the ULT so if the stack is reused, we don't risk having valid information there.

While we rarely use lineage information for RPCs themselves (i.e. knowing the parent of an RPC), I use lineage information all the time when it comes to tracking performance of bulk transfers, so I'd like to try fixing the performance problem rather than making lineage tracking optional and off by default. Could you give this PR a try with hpctoolkit?