### PR TITLE
WIP: guards and comments for deregister on null class

### DIFF
--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -566,6 +566,10 @@ hg_id_t margo_provider_register_name(margo_instance_id mid,
 
 hg_return_t margo_deregister(margo_instance_id mid, hg_id_t rpc_id)
 {
+    /* NOTE: if the hg_class is NULL, then we assume that deregistration
+     * has already been done as part of shutting down the class, so we
+     * return success here.
+     */
     if (!mid || !mid->hg.hg_class) return HG_SUCCESS;
 
     /* monitoring */

--- a/src/margo-identity.c
+++ b/src/margo-identity.c
@@ -42,6 +42,13 @@ hg_return_t margo_provider_deregister_identity(margo_instance_id mid,
     hg_id_t     id;
     hg_bool_t   flag = HG_FALSE;
     hg_return_t hret;
+
+    /* NOTE: if the hg_class is NULL, then we assume that deregistration
+     * has already been done as part of shutting down the class, so we
+     * return success here.
+     */
+    if (!mid || !mid->hg.hg_class) return HG_SUCCESS;
+
     hret = margo_provider_registered_name(mid, "__identity__", provider_id, &id,
                                           &flag);
     if (hret != HG_SUCCESS) return hret;


### PR DESCRIPTION
more safety checks for NULL hg_class when unregistering.  See https://github.com/mochi-hpc/mochi-bedrock/issues/23

I'm seeing some other problems with this in place, but I don't really know if its related or just an unfortunate coincidence.  Marking WIP for now while I try to debug.