### PR TITLE
WIP: automatic auth_key handling for some Slingshot configurations

### DIFF
--- a/src/margo-hg-config.c
+++ b/src/margo-hg-config.c
@@ -603,11 +603,7 @@ void auto_set_cxi_auth_key(const char*  protocol,
          * environment variables, but we want to pick the default index to use
          * for Mochi.
          */
-        if (vni_env_count == 1) {
-            /* there is only one VNI advertised; use it */
-            *cxi_env_idx = 0;
-            *auth_key    = strdup("0:0:0");
-        } else if (vni_env_count > 1) {
+        if (vni_env_count > 1) {
             /* there are multiple VNIs advertised; select the second one,
              * which is expected to be the job-level VNI allocated by the
              * resource manager.
@@ -615,6 +611,9 @@ void auto_set_cxi_auth_key(const char*  protocol,
             *cxi_env_idx = 1;
             *auth_key    = strdup("0:0:1");
         }
+        /* in all other cases we fall through and let the underlying libfabric
+         * select a VNI for us.
+         */
     }
 
     return;

--- a/src/margo-hg-config.c
+++ b/src/margo-hg-config.c
@@ -573,6 +573,9 @@ void auto_set_cxi_auth_key(const char*  protocol,
     }
     if (*auth_key) {
         /* auth key is already explicitly set; leave it alone */
+        /* note that users can always ask for the default service (if enabled)
+         * by explicitly setting the auth_key to "1:1"
+         */
         return;
     }
 

--- a/src/margo-hg-config.c
+++ b/src/margo-hg-config.c
@@ -269,6 +269,26 @@ bool __margo_hg_init_from_json(const struct json_object*   json,
         if (!hg->hg_class) {
             margo_error(0, "Could not initialize hg_class with protocol %s",
                         user->protocol);
+            if (cxi_used_flag && cxi_env_idx == -1) {
+                margo_error(0,
+                            "CXI initialization failed, and no SLINGSHOT "
+                            "environment variables were detected.");
+                margo_error(0,
+                            "   This may indicate that no VNI was provisioned "
+                            "for use by Mercury.");
+                margo_error(0,
+                            "   First check if a default system service is "
+                            "enabled (unlikely) by running:");
+                margo_error(0, "   `cxi_service list -s 1 -v`");
+                margo_error(0,
+                            "   If not, then you may need your system's "
+                            "resource manager to allocate a VNI.");
+                margo_error(0, "   Try launching the process using either:");
+                margo_error(0, "   `mpiexec --single-node-vni` (for PBS Pro)");
+                margo_error(
+                    0,
+                    "   `srun --network=job_vni,single_node_vni` (for SLURM)");
+            }
             goto error;
         }
         hg->hg_ownership = MARGO_OWNS_HG_CLASS;

--- a/src/margo-hg-config.c
+++ b/src/margo-hg-config.c
@@ -277,17 +277,27 @@ bool __margo_hg_init_from_json(const struct json_object*   json,
                             "   This may indicate that no VNI was provisioned "
                             "for use by Mercury.");
                 margo_error(0,
-                            "   First check if a default system service is "
-                            "enabled (unlikely) by running:");
-                margo_error(0, "   `cxi_service list -s 1 -v`");
-                margo_error(0,
-                            "   If not, then you may need your system's "
+                            "   You may need your system's "
                             "resource manager to allocate a VNI.");
                 margo_error(0, "   Try launching the process using either:");
                 margo_error(0, "   `mpiexec --single-node-vni` (for PBS Pro)");
                 margo_error(
                     0,
                     "   `srun --network=job_vni,single_node_vni` (for SLURM)");
+            } else if (cxi_used_flag) {
+                margo_error(0,
+                            "CXI initialization failed despite using SLINGSHOT "
+                            "environment variables.");
+                margo_error(0,
+                            "   Check if a default system service is "
+                            "enabled by running:");
+                margo_error(0, "   `cxi_service list -s 1 -v`");
+                margo_error(0,
+                            "   If so, then you can use it by disabling VNI "
+                            "allocation in your launcher.");
+                margo_error(0, "   Try launching the process using either:");
+                margo_error(0, "   `mpiexec --no-vni` (for PBS Pro)");
+                margo_error(0, "   `srun --network=no_vni` (for SLURM)");
             }
             goto error;
         }


### PR DESCRIPTION
Fixes #305; see description of logic there.  This is mainly an attempt to automatically select the 2nd (job level) VNI by default when multiple are provided.

To do:
* [ ] Testing (probably on Frontier)
* [ ] unit tests for the configuration code, if we can figure out something that can run on non-cxi systems

