### PR TITLE
Trace-ID to identify rpc invocation between origin/target

### DIFF
--- a/include/margo-monitoring.h
+++ b/include/margo-monitoring.h
@@ -364,7 +364,7 @@ struct margo_monitor_rpc_handler_args {
     /* input */
     hg_handle_t handle;
     hg_id_t     parent_rpc_id;
-    uint64_t parent_trace_id;
+    uint64_t    parent_trace_id;
     /* output */
     ABT_pool    pool;
     hg_return_t ret;

--- a/include/margo-monitoring.h
+++ b/include/margo-monitoring.h
@@ -296,6 +296,7 @@ struct margo_monitor_forward_args {
     hg_handle_t   handle;
     const void*   data;
     double        timeout_ms;
+    uint64_t      trace_id;
     margo_request request;
     /* output */
     hg_return_t ret;
@@ -363,6 +364,7 @@ struct margo_monitor_rpc_handler_args {
     /* input */
     hg_handle_t handle;
     hg_id_t     parent_rpc_id;
+    uint64_t parent_trace_id;
     /* output */
     ABT_pool    pool;
     hg_return_t ret;

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -58,8 +58,7 @@ static hg_id_t margo_register_internal(margo_instance_id mid,
                                        ABT_pool          pool);
 
 static hg_return_t check_error_in_output(hg_handle_t out);
-static hg_return_t check_parent_id_in_input(hg_handle_t handle,
-                                            hg_id_t*    parent_id);
+static hg_return_t check_parent_id_in_input(hg_handle_t handle, hg_id_t* parent_id, uint64_t* parent_trace_id);
 
 margo_instance_id margo_init(const char* addr_str,
                              int         mode,
@@ -968,6 +967,9 @@ static void margo_timeout_cb(void* arg)
     }
 }
 
+/* incremental per-process id for forward/respond monitoring */
+static _Atomic uint64_t trace_id_counter = 0;
+
 static hg_return_t margo_provider_iforward_internal(
     uint16_t      provider_id,
     hg_handle_t   handle,
@@ -1007,12 +1009,14 @@ static hg_return_t margo_provider_iforward_internal(
     }
 
     /* monitoring */
+    uint64_t trace_id = ++trace_id_counter;
     struct margo_monitor_forward_args monitoring_args
         = {.provider_id = provider_id,
            .handle      = handle,
            .data        = in_struct,
            .timeout_ms  = timeout_ms,
            .request     = req,
+           .trace_id    = trace_id,
            .ret         = HG_SUCCESS};
     __MARGO_MONITOR(mid, FN_START, forward, monitoring_args);
 
@@ -1120,7 +1124,7 @@ static hg_return_t margo_provider_iforward_internal(
            .request   = req,
            .user_args = (void*)in_struct,
            .user_cb   = in_cb,
-           .header    = {.parent_rpc_id = parent_rpc_id}};
+           .header    = {.parent_rpc_id = parent_rpc_id, .parent_trace_id = trace_id}};
 
     hret = HG_Forward(handle, margo_cb, (void*)req, (void*)&forward_args);
 
@@ -2442,8 +2446,10 @@ void __margo_internal_pre_handler_hooks(
     struct margo_monitor_rpc_handler_args* monitoring_args)
 {
     hg_id_t parent_id = 0;
-    check_parent_id_in_input(handle, &parent_id);
+    uint64_t parent_trace_id;
+    check_parent_id_in_input(handle, &parent_id, &parent_trace_id);
     monitoring_args->parent_rpc_id = parent_id;
+    monitoring_args->parent_trace_id = parent_trace_id;
 
     /* monitoring */
     __MARGO_MONITOR(mid, FN_START, rpc_handler, (*monitoring_args));
@@ -2601,7 +2607,7 @@ hg_return_t check_error_in_output(hg_handle_t handle)
     return hret;
 }
 
-hg_return_t check_parent_id_in_input(hg_handle_t handle, hg_id_t* parent_id)
+hg_return_t check_parent_id_in_input(hg_handle_t handle, hg_id_t* parent_id, uint64_t* parent_trace_id)
 {
     struct margo_forward_proc_args forward_args
         = {.user_args = NULL, .user_cb = NULL};
@@ -2612,6 +2618,7 @@ hg_return_t check_parent_id_in_input(hg_handle_t handle, hg_id_t* parent_id)
     // whole input.
     if (hret != HG_SUCCESS && hret != HG_CHECKSUM_ERROR) return hret;
     *parent_id = forward_args.header.parent_rpc_id;
+    *parent_trace_id = forward_args.header.parent_trace_id;
     if (hret == HG_CHECKSUM_ERROR) return HG_SUCCESS;
     HG_Free_input(handle, (void*)&forward_args);
     return HG_SUCCESS;

--- a/src/margo-core.c
+++ b/src/margo-core.c
@@ -2446,7 +2446,7 @@ void __margo_internal_pre_handler_hooks(
     struct margo_monitor_rpc_handler_args* monitoring_args)
 {
     hg_id_t parent_id = 0;
-    uint64_t parent_trace_id;
+    uint64_t parent_trace_id = 0;
     check_parent_id_in_input(handle, &parent_id, &parent_trace_id);
     monitoring_args->parent_rpc_id = parent_id;
     monitoring_args->parent_trace_id = parent_trace_id;

--- a/src/margo-serialization.h
+++ b/src/margo-serialization.h
@@ -48,7 +48,6 @@ typedef struct margo_respond_proc_args {
     hg_proc_cb_t  user_cb;
     struct {
         hg_return_t hg_ret;
-        uint64_t parent_trace_id;
     } header;
 } * margo_respond_proc_args_t;
 

--- a/src/margo-serialization.h
+++ b/src/margo-serialization.h
@@ -37,6 +37,7 @@ typedef struct margo_forward_proc_args {
     hg_proc_cb_t  user_cb;
     struct {
         hg_id_t parent_rpc_id;
+        uint64_t parent_trace_id;
     } header;
 } * margo_forward_proc_args_t;
 
@@ -47,6 +48,7 @@ typedef struct margo_respond_proc_args {
     hg_proc_cb_t  user_cb;
     struct {
         hg_return_t hg_ret;
+        uint64_t parent_trace_id;
     } header;
 } * margo_respond_proc_args_t;
 


### PR DESCRIPTION
Margo-monitoring system can capture the origin/target address, which is enough to identify a unique margo instance. But uniquely identifying the same RPC invocation on both the client and server monitoring side was not possible.

With this change, a trace-id is generated, shared in the `forward` arguments for monitoring, and send with the rpc header. The trace-id is implemented as an atomic counter that is unique to the process. The target then captures that trace-id and includes it in the `rpc_handler` arguments, allowing the monitoring system to use both the address and the trace-id to uniquely identify the rpc invocation on both ends.